### PR TITLE
Fix macOS service manager acting on the wrong launchd label

### DIFF
--- a/src/yank/platform/macos/service.py
+++ b/src/yank/platform/macos/service.py
@@ -20,6 +20,10 @@ class MacOSServiceManager(ServiceManager):
 
     PLIST_NAME = "com.yank.agent.plist"
     HOMEBREW_PLIST_NAME = "homebrew.mxcl.yank.plist"
+    HOMEBREW_LABEL = "homebrew.mxcl.yank"
+
+    # launchctl reports POSIX errno values; ESRCH means "no such service loaded"
+    _ESRCH = 3
 
     def __init__(self):
         self._plist_path = Path.home() / "Library" / "LaunchAgents" / self.PLIST_NAME
@@ -68,12 +72,38 @@ class MacOSServiceManager(ServiceManager):
             return False, str(e)
 
     def uninstall(self) -> Tuple[bool, str]:
-        try:
-            # Bootout first (ignoring errors if not loaded)
-            self._launchctl("bootout", f"gui/{self._uid}/{self.SERVICE_LABEL}", check=False)
+        """Remove our own LaunchAgent.
 
-            if self._plist_path.exists():
+        A Homebrew-managed agent is deliberately left alone: deleting
+        ``homebrew.mxcl.yank.plist`` behind brew's back desyncs
+        ``brew services list``, so we report it instead of guessing.
+        """
+        try:
+            own_installed = self._plist_path.exists()
+            homebrew_installed = self._homebrew_plist_path.exists()
+
+            if own_installed:
+                # Bootout first (ignoring errors if not loaded)
+                try:
+                    self._launchctl(
+                        "bootout", f"gui/{self._uid}/{self.SERVICE_LABEL}", check=False
+                    )
+                except subprocess.TimeoutExpired:
+                    logger.warning("launchctl bootout timed out for %s", self.SERVICE_LABEL)
                 self._plist_path.unlink()
+
+            if homebrew_installed:
+                brew_note = (
+                    f"{self.HOMEBREW_LABEL} is managed by Homebrew and was left in place - "
+                    "run 'brew services stop yank' to remove it"
+                )
+                logger.warning("uninstall: %s", brew_note)
+                if own_installed:
+                    return True, f"Uninstalled {self.SERVICE_LABEL}. Note: {brew_note}"
+                return False, f"Not uninstalled: {brew_note}"
+
+            if not own_installed:
+                return True, "Not installed"
 
             return True, "Uninstalled"
         except Exception as e:
@@ -82,58 +112,129 @@ class MacOSServiceManager(ServiceManager):
     # ── start / stop ─────────────────────────────────────────────────
 
     def start(self) -> Tuple[bool, str]:
-        if not self._plist_path.exists():
+        label, info = self._resolve()
+
+        if info.status == ServiceStatus.RUNNING:
+            if label == self.HOMEBREW_LABEL:
+                return True, f"Already running (PID {info.pid}, managed by Homebrew)"
+            if not self._needs_reinstall():
+                return True, f"Already running (PID {info.pid})"
+            # Stale binary path in our plist — reload it.
+            ok, msg = self.stop()
+            if not ok:
+                return False, msg
             ok, msg = self.install()
             if not ok:
                 return False, msg
+            label = self.SERVICE_LABEL
+        elif label != self.HOMEBREW_LABEL:
+            # Nothing installed, or only our own plist: make sure it exists.
+            # A Homebrew-managed agent is loaded as-is so we never end up with
+            # two RunAtLoad agents racing for the same port.
+            if not self._plist_path.exists():
+                ok, msg = self.install()
+                if not ok:
+                    return False, msg
+            label = self.SERVICE_LABEL
 
-        # Check if already loaded
-        info = self.get_status()
-        if info.status == ServiceStatus.RUNNING:
-            if self._needs_reinstall():
-                self.stop()
-                self.install()
-            else:
-                return True, f"Already running (PID {info.pid})"
+        plist_path = self._plist_for(label)
 
         # Bootstrap (load) the agent
-        result = self._launchctl("bootstrap", f"gui/{self._uid}", str(self._plist_path), check=False)
+        try:
+            result = self._launchctl(
+                "bootstrap", f"gui/{self._uid}", str(plist_path), check=False
+            )
+        except subprocess.TimeoutExpired:
+            return False, "launchctl bootstrap timed out"
+
         if result.returncode != 0:
             # May already be loaded — try kickstart (with longer timeout)
             try:
                 result = self._launchctl(
-                    "kickstart", "-k", f"gui/{self._uid}/{self.SERVICE_LABEL}",
+                    "kickstart", "-k", f"gui/{self._uid}/{label}",
                     check=False, timeout=30,
                 )
             except subprocess.TimeoutExpired:
                 return False, "launchctl kickstart timed out"
             if result.returncode != 0:
-                return False, f"launchctl failed: {result.stderr.strip()}"
+                return False, f"launchctl failed: {self._stderr(result)}"
 
         return True, "Started"
 
     def stop(self) -> Tuple[bool, str]:
-        info = self.get_status()
-        if info.status != ServiceStatus.RUNNING:
+        label, info = self._resolve()
+        if label is None or info.status != ServiceStatus.RUNNING:
             return True, "Not running"
 
-        # Must bootout to prevent KeepAlive from restarting the process
-        self._launchctl("bootout", f"gui/{self._uid}/{self.SERVICE_LABEL}", check=False)
+        # Must bootout to prevent KeepAlive from restarting the process.
+        # Act on whichever label is actually loaded — a Homebrew install runs
+        # under homebrew.mxcl.yank, not com.yank.agent.
+        try:
+            result = self._launchctl("bootout", f"gui/{self._uid}/{label}", check=False)
+        except subprocess.TimeoutExpired:
+            return False, "launchctl bootout timed out"
+
+        if result.returncode == self._ESRCH:
+            # Raced with the agent exiting on its own — it is gone either way.
+            return True, "Not running"
+
+        if result.returncode != 0:
+            return False, f"launchctl bootout {label} failed: {self._stderr(result)}"
+
+        if label == self.HOMEBREW_LABEL:
+            return True, (
+                "Stopped homebrew.mxcl.yank. Run 'brew services stop yank' "
+                "so it stays stopped after a reboot."
+            )
 
         return True, "Stopped"
 
     # ── status ───────────────────────────────────────────────────────
 
     def get_status(self) -> ServiceInfo:
-        if not self._plist_path.exists():
-            # Check for Homebrew-managed plist (brew services start yank)
-            if self._homebrew_plist_path.exists():
-                return self._get_homebrew_status()
-            return ServiceInfo(status=ServiceStatus.NOT_INSTALLED)
+        _label, info = self._resolve()
+        return info
 
-        result = self._launchctl("print", f"gui/{self._uid}/{self.SERVICE_LABEL}", check=False)
+    # ── internal helpers ─────────────────────────────────────────────
+
+    def _resolve(self) -> Tuple[Optional[str], ServiceInfo]:
+        """Work out which LaunchAgent label actually governs Yank.
+
+        Yank can be installed by us (``com.yank.agent``) or by Homebrew
+        (``homebrew.mxcl.yank``), and both plists can be present at once.
+        Whichever label is actually loaded and running wins, so that
+        start()/stop() act on the agent the user can see; ours breaks ties.
+
+        Returns ``(label, info)``. ``label`` is None only when nothing is
+        installed at all; otherwise it is the label to act on.
+        """
+        candidates: List[str] = []
+        if self._plist_path.exists():
+            candidates.append(self.SERVICE_LABEL)
+        if self._homebrew_plist_path.exists():
+            candidates.append(self.HOMEBREW_LABEL)
+
+        if not candidates:
+            return None, ServiceInfo(status=ServiceStatus.NOT_INSTALLED)
+
+        for label in candidates:
+            info = self._probe(label)
+            if info is not None and info.status == ServiceStatus.RUNNING:
+                return label, info
+
+        # Installed, but nothing is loaded and running.
+        return candidates[0], ServiceInfo(status=ServiceStatus.STOPPED, enabled=True)
+
+    def _probe(self, label: str) -> Optional[ServiceInfo]:
+        """Query launchctl for one label. Returns None when it is not loaded."""
+        try:
+            result = self._launchctl("print", f"gui/{self._uid}/{label}", check=False)
+        except subprocess.TimeoutExpired:
+            logger.warning("launchctl print timed out for %s", label)
+            return None
+
         if result.returncode != 0:
-            return ServiceInfo(status=ServiceStatus.STOPPED, enabled=True)
+            return None
 
         # Parse PID from launchctl print output
         pid = self._parse_pid(result.stdout)
@@ -142,21 +243,16 @@ class MacOSServiceManager(ServiceManager):
 
         return ServiceInfo(status=ServiceStatus.STOPPED, enabled=True)
 
-    def _get_homebrew_status(self) -> ServiceInfo:
-        """Check status of Homebrew-managed LaunchAgent."""
-        # Homebrew uses label "homebrew.mxcl.yank"
-        homebrew_label = "homebrew.mxcl.yank"
-        result = self._launchctl("print", f"gui/{self._uid}/{homebrew_label}", check=False)
-        if result.returncode != 0:
-            return ServiceInfo(status=ServiceStatus.STOPPED, enabled=True)
+    def _plist_for(self, label: str) -> Path:
+        if label == self.HOMEBREW_LABEL:
+            return self._homebrew_plist_path
+        return self._plist_path
 
-        pid = self._parse_pid(result.stdout)
-        if pid and pid > 0:
-            return ServiceInfo(status=ServiceStatus.RUNNING, pid=pid, enabled=True)
-
-        return ServiceInfo(status=ServiceStatus.STOPPED, enabled=True)
-
-    # ── internal helpers ─────────────────────────────────────────────
+    @staticmethod
+    def _stderr(result: subprocess.CompletedProcess) -> str:
+        """Human-readable failure detail from a launchctl result."""
+        err = (result.stderr or "").strip()
+        return err or f"exit code {result.returncode}"
 
     def _needs_reinstall(self) -> bool:
         """Check if plist ProgramArguments matches current binary."""
@@ -183,9 +279,17 @@ class MacOSServiceManager(ServiceManager):
 
     @staticmethod
     def _launchctl(*args, check: bool = True, timeout: int = 10) -> subprocess.CompletedProcess:
+        """Run launchctl.
+
+        With ``check=True`` a non-zero exit raises ``CalledProcessError``; every
+        caller here passes ``check=False`` and inspects ``returncode`` itself,
+        because launchctl uses non-zero exits for ordinary states such as
+        "service not loaded".
+        """
         return subprocess.run(
             ["launchctl", *args],
             capture_output=True,
             text=True,
             timeout=timeout,
+            check=check,
         )

--- a/src/yank/platform/macos/service.py
+++ b/src/yank/platform/macos/service.py
@@ -207,6 +207,13 @@ class MacOSServiceManager(ServiceManager):
 
         Returns ``(label, info)``. ``label`` is None only when nothing is
         installed at all; otherwise it is the label to act on.
+
+        Caveat: if both agents were somehow running at once, the tie-break
+        picks ours, so stop() would boot out ours and leave the Homebrew one
+        running while reporting "Stopped". That state is largely unreachable —
+        singleton.py makes the loser of the port-9876 bind exit — and it is no
+        worse than the old behaviour, which never looked at the Homebrew label
+        at all.
         """
         candidates: List[str] = []
         if self._plist_path.exists():

--- a/tests/unit/test_service_status.py
+++ b/tests/unit/test_service_status.py
@@ -7,6 +7,7 @@ Covers:
 - Self-healing: auto-install when paired but service missing
 """
 import subprocess
+import sys
 from pathlib import Path
 from unittest.mock import patch, MagicMock, PropertyMock
 
@@ -15,9 +16,21 @@ import pytest
 from yank.common.service_manager import ServiceInfo, ServiceStatus
 
 
+# MacOSServiceManager.__init__ calls os.getuid(), which does not exist on
+# Windows, so every class that constructs one is darwin-only. A module-level
+# mark would be wrong here: the Linux and cmd_status classes below are
+# platform-agnostic (they only touch mocks and tmp_path) and must keep running
+# everywhere.
+requires_macos = pytest.mark.skipif(
+    sys.platform != "darwin",
+    reason="macOS LaunchAgent manager (MacOSServiceManager.__init__ needs os.getuid)",
+)
+
+
 # ── macOS: Homebrew plist detection ──────────────────────────────────────
 
 
+@requires_macos
 class TestMacOSHomebrewDetection:
     """MacOSServiceManager.get_status() should detect Homebrew-managed plist."""
 
@@ -123,11 +136,16 @@ class TestMacOSHomebrewDetection:
 # ── macOS: stop / uninstall / start act on the right label ───────────────
 
 
+@requires_macos
 class _MacOSServiceTestBase:
     """Shared fixture: a MacOSServiceManager rooted in tmp_path.
 
     subprocess.run is patched out for every test in these classes so a real
     launchctl invocation can never escape and mutate the host's launchd state.
+
+    The darwin-only mark is inherited by subclasses, so a new subclass cannot
+    accidentally start erroring on the Windows CI leg; it is also repeated on
+    each subclass so the constraint is greppable.
     """
 
     @pytest.fixture(autouse=True)
@@ -157,6 +175,7 @@ class _MacOSServiceTestBase:
         self.mgr._homebrew_plist_path.write_bytes(b"<plist/>")
 
 
+@requires_macos
 class TestMacOSStop(_MacOSServiceTestBase):
     """stop() must boot out the label that is actually loaded (issue #11)."""
 
@@ -262,6 +281,7 @@ class TestMacOSStop(_MacOSServiceTestBase):
         mock_lctl.assert_not_called()
 
 
+@requires_macos
 class TestMacOSUninstall(_MacOSServiceTestBase):
     """uninstall() must not silently claim success for a brew-managed agent."""
 
@@ -321,6 +341,7 @@ class TestMacOSUninstall(_MacOSServiceTestBase):
         assert not self.mgr._plist_path.exists()
 
 
+@requires_macos
 class TestMacOSStart(_MacOSServiceTestBase):
     """start() error handling and Homebrew awareness (issues #11, #15)."""
 
@@ -408,6 +429,7 @@ class TestMacOSStart(_MacOSServiceTestBase):
         assert "Bad request" in msg
 
 
+@requires_macos
 class TestMacOSLaunchctlWrapper(_MacOSServiceTestBase):
     """_launchctl must honour its `check` argument (issue #15)."""
 
@@ -449,6 +471,10 @@ class TestMacOSLaunchctlWrapper(_MacOSServiceTestBase):
 # ── Linux: package-provided unit detection ───────────────────────────────
 
 
+# Deliberately NOT marked darwin/linux-only: LinuxServiceManager.__init__ only
+# reads XDG_CONFIG_HOME and Path.home(), the module imports nothing POSIX-only,
+# and every test here drives mocked _systemctl/install against tmp_path. It
+# already runs green on macOS, so it is portable to the Windows leg too.
 class TestLinuxPackageUnitDetection:
     """LinuxServiceManager.get_status() should detect /usr/lib/systemd/user unit."""
 

--- a/tests/unit/test_service_status.py
+++ b/tests/unit/test_service_status.py
@@ -93,6 +93,358 @@ class TestMacOSHomebrewDetection:
         call_args = mock_lctl.call_args[0]
         assert "com.yank.agent" in call_args[1]
 
+    def test_homebrew_running_wins_when_own_plist_is_not_loaded(self):
+        """Both plists present but only the Homebrew agent is loaded."""
+        self.mgr._plist_path.parent.mkdir(parents=True, exist_ok=True)
+        self.mgr._plist_path.write_bytes(b"<plist/>")
+        self.mgr._homebrew_plist_path.write_bytes(b"<plist/>")
+
+        with patch.object(self.mgr, "_launchctl") as mock_lctl:
+            mock_lctl.side_effect = [
+                MagicMock(returncode=113, stdout="", stderr=""),   # com.yank.agent
+                MagicMock(returncode=0, stdout="pid = 4242\n"),    # homebrew.mxcl.yank
+            ]
+            info = self.mgr.get_status()
+
+        assert info.status == ServiceStatus.RUNNING
+        assert info.pid == 4242
+
+    def test_status_survives_launchctl_timeout(self):
+        self.mgr._plist_path.parent.mkdir(parents=True, exist_ok=True)
+        self.mgr._plist_path.write_bytes(b"<plist/>")
+
+        with patch.object(self.mgr, "_launchctl") as mock_lctl:
+            mock_lctl.side_effect = subprocess.TimeoutExpired(cmd="launchctl", timeout=10)
+            info = self.mgr.get_status()
+
+        assert info.status == ServiceStatus.STOPPED
+
+
+# ── macOS: stop / uninstall / start act on the right label ───────────────
+
+
+class _MacOSServiceTestBase:
+    """Shared fixture: a MacOSServiceManager rooted in tmp_path.
+
+    subprocess.run is patched out for every test in these classes so a real
+    launchctl invocation can never escape and mutate the host's launchd state.
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup(self, tmp_path):
+        with patch("yank.platform.macos.service.Path.home", return_value=tmp_path):
+            from yank.platform.macos.service import MacOSServiceManager
+            self.mgr = MacOSServiceManager()
+        self.launch_agents = tmp_path / "Library" / "LaunchAgents"
+        self.launch_agents.mkdir(parents=True)
+
+        def _no_real_launchctl(*args, **kwargs):
+            raise AssertionError(f"real subprocess call escaped: {args!r}")
+
+        with patch("yank.platform.macos.service.subprocess.run") as mock_run:
+            mock_run.side_effect = _no_real_launchctl
+            self.run_mock = mock_run
+            yield
+
+    @staticmethod
+    def _completed(returncode=0, stdout="", stderr=""):
+        return MagicMock(returncode=returncode, stdout=stdout, stderr=stderr)
+
+    def _install_own_plist(self):
+        self.mgr._plist_path.write_bytes(b"<plist/>")
+
+    def _install_homebrew_plist(self):
+        self.mgr._homebrew_plist_path.write_bytes(b"<plist/>")
+
+
+class TestMacOSStop(_MacOSServiceTestBase):
+    """stop() must boot out the label that is actually loaded (issue #11)."""
+
+    def test_stops_homebrew_label_when_only_homebrew_plist_exists(self):
+        self._install_homebrew_plist()
+
+        with patch.object(self.mgr, "_launchctl") as mock_lctl:
+            mock_lctl.side_effect = [
+                self._completed(stdout="pid = 777\n"),  # print homebrew.mxcl.yank
+                self._completed(),                      # bootout
+            ]
+            ok, msg = self.mgr.stop()
+
+        assert ok is True
+        bootout_args = mock_lctl.call_args_list[-1][0]
+        assert bootout_args[0] == "bootout"
+        assert bootout_args[1].endswith("/homebrew.mxcl.yank")
+        assert "brew services stop yank" in msg
+
+    def test_stops_own_label_when_own_plist_is_loaded(self):
+        self._install_own_plist()
+        self._install_homebrew_plist()
+
+        with patch.object(self.mgr, "_launchctl") as mock_lctl:
+            mock_lctl.side_effect = [
+                self._completed(stdout="pid = 12\n"),  # print com.yank.agent
+                self._completed(),                     # bootout
+            ]
+            ok, msg = self.mgr.stop()
+
+        assert (ok, msg) == (True, "Stopped")
+        bootout_args = mock_lctl.call_args_list[-1][0]
+        assert bootout_args[1].endswith("/com.yank.agent")
+
+    def test_reports_failure_when_bootout_fails(self):
+        self._install_own_plist()
+
+        with patch.object(self.mgr, "_launchctl") as mock_lctl:
+            mock_lctl.side_effect = [
+                self._completed(stdout="pid = 12\n"),
+                self._completed(returncode=1, stderr="Boot-out failed: 5: Input/output error\n"),
+            ]
+            ok, msg = self.mgr.stop()
+
+        assert ok is False
+        assert "Input/output error" in msg
+        assert "com.yank.agent" in msg
+
+    def test_reports_failure_when_bootout_fails_without_stderr(self):
+        self._install_own_plist()
+
+        with patch.object(self.mgr, "_launchctl") as mock_lctl:
+            mock_lctl.side_effect = [
+                self._completed(stdout="pid = 12\n"),
+                self._completed(returncode=36, stderr=""),
+            ]
+            ok, msg = self.mgr.stop()
+
+        assert ok is False
+        assert "exit code 36" in msg
+
+    def test_bootout_esrch_is_treated_as_already_stopped(self):
+        """The agent can exit between the status probe and the bootout."""
+        self._install_own_plist()
+
+        with patch.object(self.mgr, "_launchctl") as mock_lctl:
+            mock_lctl.side_effect = [
+                self._completed(stdout="pid = 12\n"),
+                self._completed(returncode=3, stderr="Boot-out failed: 3: No such process\n"),
+            ]
+            ok, msg = self.mgr.stop()
+
+        assert (ok, msg) == (True, "Not running")
+
+    def test_reports_failure_when_bootout_times_out(self):
+        self._install_own_plist()
+
+        with patch.object(self.mgr, "_launchctl") as mock_lctl:
+            mock_lctl.side_effect = [
+                self._completed(stdout="pid = 12\n"),
+                subprocess.TimeoutExpired(cmd="launchctl", timeout=10),
+            ]
+            ok, msg = self.mgr.stop()
+
+        assert ok is False
+        assert "timed out" in msg
+
+    def test_not_running_does_not_bootout(self):
+        self._install_own_plist()
+
+        with patch.object(self.mgr, "_launchctl") as mock_lctl:
+            mock_lctl.return_value = self._completed(returncode=113)
+            ok, msg = self.mgr.stop()
+
+        assert (ok, msg) == (True, "Not running")
+        assert all(call[0][0] == "print" for call in mock_lctl.call_args_list)
+
+    def test_nothing_installed_is_not_running(self):
+        with patch.object(self.mgr, "_launchctl") as mock_lctl:
+            ok, msg = self.mgr.stop()
+
+        assert (ok, msg) == (True, "Not running")
+        mock_lctl.assert_not_called()
+
+
+class TestMacOSUninstall(_MacOSServiceTestBase):
+    """uninstall() must not silently claim success for a brew-managed agent."""
+
+    def test_homebrew_only_is_reported_not_deleted(self):
+        self._install_homebrew_plist()
+
+        with patch.object(self.mgr, "_launchctl") as mock_lctl:
+            ok, msg = self.mgr.uninstall()
+
+        assert ok is False
+        assert "brew services stop yank" in msg
+        # Homebrew's plist is left for brew to manage
+        assert self.mgr._homebrew_plist_path.exists()
+        mock_lctl.assert_not_called()
+
+    def test_own_plist_removed_and_homebrew_reported(self):
+        self._install_own_plist()
+        self._install_homebrew_plist()
+
+        with patch.object(self.mgr, "_launchctl") as mock_lctl:
+            mock_lctl.return_value = self._completed()
+            ok, msg = self.mgr.uninstall()
+
+        assert ok is True
+        assert not self.mgr._plist_path.exists()
+        assert self.mgr._homebrew_plist_path.exists()
+        assert "brew services stop yank" in msg
+        bootout_args = mock_lctl.call_args_list[-1][0]
+        assert bootout_args[0] == "bootout"
+        assert bootout_args[1].endswith("/com.yank.agent")
+
+    def test_own_plist_only(self):
+        self._install_own_plist()
+
+        with patch.object(self.mgr, "_launchctl") as mock_lctl:
+            mock_lctl.return_value = self._completed()
+            ok, msg = self.mgr.uninstall()
+
+        assert (ok, msg) == (True, "Uninstalled")
+        assert not self.mgr._plist_path.exists()
+
+    def test_nothing_installed(self):
+        with patch.object(self.mgr, "_launchctl") as mock_lctl:
+            ok, msg = self.mgr.uninstall()
+
+        assert (ok, msg) == (True, "Not installed")
+        mock_lctl.assert_not_called()
+
+    def test_bootout_timeout_does_not_block_plist_removal(self):
+        self._install_own_plist()
+
+        with patch.object(self.mgr, "_launchctl") as mock_lctl:
+            mock_lctl.side_effect = subprocess.TimeoutExpired(cmd="launchctl", timeout=10)
+            ok, msg = self.mgr.uninstall()
+
+        assert ok is True
+        assert not self.mgr._plist_path.exists()
+
+
+class TestMacOSStart(_MacOSServiceTestBase):
+    """start() error handling and Homebrew awareness (issues #11, #15)."""
+
+    def test_bootstrap_timeout_returns_error_not_traceback(self):
+        self._install_own_plist()
+
+        with patch.object(self.mgr, "_launchctl") as mock_lctl:
+            mock_lctl.side_effect = [
+                self._completed(returncode=113),  # print: not loaded
+                subprocess.TimeoutExpired(cmd="launchctl", timeout=10),  # bootstrap
+            ]
+            ok, msg = self.mgr.start()
+
+        assert ok is False
+        assert "bootstrap timed out" in msg
+
+    def test_kickstart_timeout_returns_error(self):
+        self._install_own_plist()
+
+        with patch.object(self.mgr, "_launchctl") as mock_lctl:
+            mock_lctl.side_effect = [
+                self._completed(returncode=113),  # print: not loaded
+                self._completed(returncode=5),    # bootstrap fails
+                subprocess.TimeoutExpired(cmd="launchctl", timeout=30),  # kickstart
+            ]
+            ok, msg = self.mgr.start()
+
+        assert ok is False
+        assert "kickstart timed out" in msg
+
+    def test_already_running_under_homebrew_does_not_install(self):
+        self._install_homebrew_plist()
+
+        with patch.object(self.mgr, "_launchctl") as mock_lctl, \
+             patch.object(self.mgr, "install") as mock_install:
+            mock_lctl.return_value = self._completed(stdout="pid = 31337\n")
+            ok, msg = self.mgr.start()
+
+        assert ok is True
+        assert "31337" in msg
+        mock_install.assert_not_called()
+        assert not self.mgr._plist_path.exists()
+
+    def test_stopped_homebrew_agent_is_bootstrapped_not_duplicated(self):
+        """Never install a second RunAtLoad agent alongside Homebrew's."""
+        self._install_homebrew_plist()
+
+        with patch.object(self.mgr, "_launchctl") as mock_lctl, \
+             patch.object(self.mgr, "install") as mock_install:
+            mock_lctl.side_effect = [
+                self._completed(returncode=113),  # print: not loaded
+                self._completed(),                # bootstrap
+            ]
+            ok, msg = self.mgr.start()
+
+        assert (ok, msg) == (True, "Started")
+        mock_install.assert_not_called()
+        bootstrap_args = mock_lctl.call_args_list[-1][0]
+        assert bootstrap_args[0] == "bootstrap"
+        assert bootstrap_args[2] == str(self.mgr._homebrew_plist_path)
+
+    def test_installs_own_plist_when_nothing_is_installed(self):
+        with patch.object(self.mgr, "_launchctl") as mock_lctl:
+            mock_lctl.return_value = self._completed()
+            ok, msg = self.mgr.start()
+
+        assert (ok, msg) == (True, "Started")
+        assert self.mgr._plist_path.exists()
+        bootstrap_args = mock_lctl.call_args_list[-1][0]
+        assert bootstrap_args[0] == "bootstrap"
+        assert bootstrap_args[2] == str(self.mgr._plist_path)
+
+    def test_bootstrap_failure_is_reported(self):
+        self._install_own_plist()
+
+        with patch.object(self.mgr, "_launchctl") as mock_lctl:
+            mock_lctl.side_effect = [
+                self._completed(returncode=113),                      # print
+                self._completed(returncode=5, stderr="Bootstrap failed\n"),
+                self._completed(returncode=5, stderr="Bad request\n"),  # kickstart
+            ]
+            ok, msg = self.mgr.start()
+
+        assert ok is False
+        assert "Bad request" in msg
+
+
+class TestMacOSLaunchctlWrapper(_MacOSServiceTestBase):
+    """_launchctl must honour its `check` argument (issue #15)."""
+
+    def test_check_is_passed_through_to_subprocess(self):
+        self.run_mock.side_effect = None
+        self.run_mock.return_value = self._completed()
+
+        self.mgr._launchctl("print", "gui/501/com.yank.agent", check=False)
+        assert self.run_mock.call_args.kwargs["check"] is False
+
+        self.mgr._launchctl("print", "gui/501/com.yank.agent")
+        assert self.run_mock.call_args.kwargs["check"] is True
+
+    def test_check_true_raises_on_failure(self):
+        def fake_run(cmd, **kwargs):
+            # Mimic subprocess.run's own contract for check=True
+            if kwargs.get("check"):
+                raise subprocess.CalledProcessError(1, cmd)
+            return self._completed(returncode=1)
+
+        self.run_mock.side_effect = fake_run
+
+        with pytest.raises(subprocess.CalledProcessError):
+            self.mgr._launchctl("bootout", "gui/501/com.yank.agent")
+
+        # check=False keeps the old behaviour: inspect returncode yourself
+        assert self.mgr._launchctl(
+            "bootout", "gui/501/com.yank.agent", check=False
+        ).returncode == 1
+
+    def test_timeout_is_passed_through(self):
+        self.run_mock.side_effect = None
+        self.run_mock.return_value = self._completed()
+
+        self.mgr._launchctl("kickstart", "-k", "gui/501/com.yank.agent", timeout=30)
+        assert self.run_mock.call_args.kwargs["timeout"] == 30
+
 
 # ── Linux: package-provided unit detection ───────────────────────────────
 


### PR DESCRIPTION
## What

`yank stop` lied to Homebrew users, and `yank unpair` left the agent installed and running.

`get_status()` already fell back to the Homebrew-managed plist and reported RUNNING under the label `homebrew.mxcl.yank`, but the two methods that act on the service did not:

- `stop()` always booted out `com.yank.agent`, ignored launchctl's return code entirely, and unconditionally returned `(True, "Stopped")`.
- `uninstall()` only ever touched our own plist path.

Homebrew is the primary macOS distribution channel (the release workflow updates the tap), so for those users `yank stop` printed `[OK] Stopped` while the agent carried on syncing, and `yank unpair` (via `stop_and_uninstall`) reported nothing while leaving the agent in place.

## How

- New `_resolve()` returns `(label, ServiceInfo)` for whichever LaunchAgent is actually loaded. Both plists can be present at once, so each candidate is probed and the one that is really running wins; ours breaks ties, and when nothing is running we fall back to the preferred (own) install. `get_status()` is now a thin wrapper over it, so its existing behaviour is unchanged apart from correctly reporting a running Homebrew agent even when a stale `com.yank.agent` plist is also on disk.
- `stop()` boots out the **resolved** label and returns launchctl's real outcome, surfacing stderr (or the exit code when stderr is empty). Exit code 3 (`ESRCH`) is reported as `Not running` rather than a failure, since that just means the agent exited between the probe and the bootout.
- `start()` loads the resolved label's plist. Previously a Homebrew install with a stopped agent would get a *second* `com.yank.agent` plist written with `RunAtLoad`, so at the next login two agents would race for port 9876 and one would die on the singleton check.

### Residual case, documented in the docstring

If **both** agents were somehow running at once, the tie-break picks ours: `stop()` boots out ours and the Homebrew one keeps running while we report "Stopped". This is not a regression (the old code never looked at the Homebrew label at all) and is largely unreachable, because `singleton.py` makes whichever process loses the port-9876 bind exit. It is now called out in `_resolve()`'s docstring rather than left implicit.

### Judgement call: `uninstall()` does not delete Homebrew's plist

`brew services` derives its state from `~/Library/LaunchAgents/homebrew.mxcl.yank.plist`. Deleting it behind brew's back leaves `brew services list` describing a service that no longer exists, and a later `brew services restart/stop yank` then misbehaves — worse than the situation we are fixing. So `uninstall()`:

- removes **our** plist (booting it out first) when it exists;
- leaves a Homebrew-managed plist alone and says so, pointing at `brew services stop yank`;
- returns `False` when the *only* thing installed is brew's, because nothing was in fact uninstalled — honest reporting is the whole point of this issue.

Note that `cmd_unpair` in `main.py` discards the message on failure (`if ok: print(...)`), so a brew user currently sees silence rather than the explanation. Fixing that print is in `main.py`, which is outside this change's scope; the message is also logged at warning level. Worth a follow-up.

## Also fixed (#15)

- `_launchctl(*args, check=True, timeout=10)` accepted `check` and never forwarded it to `subprocess.run`. It is now passed through, with a docstring explaining why every caller here passes `check=False` (launchctl uses non-zero exits for ordinary states like "not loaded"). No behaviour change today; the next caller relying on it gets an exception instead of silence.
- The `bootstrap` call in `start()` was not wrapped for `subprocess.TimeoutExpired` even though the `kickstart` call below it was, so a slow launchctl made `yank start` exit with a traceback. It now returns `(False, "launchctl bootstrap timed out")`. The `bootout` calls in `stop()`/`uninstall()` got the same treatment.

## Testing

`tests/unit/test_service_status.py` grows from 13 to 37 tests; full suite 111 passed (baseline was 87). Of the 24 new tests, 16 fail if the `service.py` change is reverted.

New coverage: stop() booting out the Homebrew label when only brew's plist exists, stop() reporting bootout failure / empty stderr / timeout / ESRCH, uninstall() with a Homebrew-managed agent (both alone and alongside ours), start()'s bootstrap-timeout path, start() not duplicating a brew-managed agent, and `_launchctl` forwarding `check`/`timeout`.

**No launchctl invocation escapes the test suite.** Every case patches `_launchctl` or `subprocess.run`, and the shared fixture patches `yank.platform.macos.service.subprocess.run` with a side effect that fails the test if a real call is ever attempted. No system-level e2e was run: it would mutate the developer's real launchd state.

## Platform guards for the incoming Windows CI leg

`MacOSServiceManager.__init__` calls `os.getuid()`, which does not exist on Windows, so every class that constructs one errors on the `windows-latest` leg that #22 introduces. The fixtures patch `Path.home` but leave `os.getuid` exposed (confirmed locally: with `os.getuid` patched to raise, the constructor raises `AttributeError`).

A shared `requires_macos = pytest.mark.skipif(sys.platform != "darwin", ...)` is now applied **per class** — to the four classes added here, to `_MacOSServiceTestBase` so future subclasses inherit it, and to the pre-existing `TestMacOSHomebrewDetection`. A module-level `pytestmark` would be wrong for this file, because `TestLinuxPackageUnitDetection` and `TestCmdStatusSelfHealing` are platform-agnostic and should keep running on every leg.

`TestLinuxPackageUnitDetection` is deliberately left unguarded, verified rather than assumed: `LinuxServiceManager.__init__` only reads `XDG_CONFIG_HOME` and `Path.home()`, `linux/service.py` imports nothing POSIX-only, and every test there drives mocked `_systemctl`/`install` against `tmp_path`. It already runs green on macOS, so it is portable to Windows. The reasoning is recorded in a comment above the class so nobody has to re-derive it.

**This makes the per-class `--deselect` for `TestMacOSHomebrewDetection` in #22's `ci.yml` redundant and it can be dropped once this lands.** I have not touched `ci.yml` — that file belongs to #22.

Verification: 111 passed on macOS, unchanged by the guards. With the skipif condition temporarily inverted, the file reports **8 passed / 29 skipped with zero errors**, which is what the Windows leg will see. I cannot run the Windows leg locally — that confirmation has to come from CI on #22.

Closes #11
Closes #15
