### PR TITLE
Add pull-request CI workflow (pytest + ruff blocking, black/mypy advisory)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,19 @@ jobs:
         include:
           - os: macos-latest
             extras: macos
+            pytest_args: ''
           - os: windows-latest
             extras: windows
+            # tests/unit/test_service_status.py::TestMacOSHomebrewDetection has
+            # no platform skip guard, so it runs on Windows and errors 5 times:
+            # it constructs MacOSServiceManager, and macos/service.py:29 calls
+            # os.getuid(), which does not exist on Windows. That is a test-suite
+            # portability bug, not a CI bug, and fixing tests/ is out of scope
+            # for this workflow. Deselect it so the Windows leg reflects real
+            # regressions instead of failing on every PR. Remove this once the
+            # class is guarded with @pytest.mark.skipif(sys.platform != 'darwin')
+            # - a stale nodeid here is harmless, --deselect no-ops if unmatched.
+            pytest_args: '--deselect tests/unit/test_service_status.py::TestMacOSHomebrewDetection'
 
     runs-on: ${{ matrix.os }}
 
@@ -56,7 +67,7 @@ jobs:
           pip install -e ".[dev,${{ matrix.extras }}]"
 
       - name: Run tests
-        run: pytest
+        run: pytest ${{ matrix.pytest_args }}
 
       # Blocking lint. Deliberately scoped to a subset of the project's ruff
       # config that is already clean across src/ and tests/, so this acts as a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,94 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+# One run per PR (or per branch). A new push supersedes the in-flight run for
+# the same ref, so stale PR runs get cancelled instead of burning runner time.
+# Pushes to master are never cancelled - they are the record of what landed.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  test:
+    name: Test (${{ matrix.os }})
+
+    # No ubuntu job on purpose. Yank targets Windows and macOS; the Linux
+    # platform package (src/yank/platform/linux/) is known-broken and out of
+    # scope, so a Linux leg would fail immediately and red-gate every PR.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-latest
+            extras: macos
+          - os: windows-latest
+            extras: windows
+
+    runs-on: ${{ matrix.os }}
+
+    # The suite runs in ~10s; this only exists so a hung socket or thread in a
+    # future test cannot sit on a runner for the default six hours.
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      # Editable install so that pytest's `--cov=yank` (hardcoded in
+      # pyproject's addopts) resolves to src/yank rather than site-packages.
+      # The dev extra supplies pytest, pytest-cov, ruff, black and mypy.
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          pip install -e ".[dev,${{ matrix.extras }}]"
+
+      - name: Run tests
+        run: pytest
+
+      # Blocking lint. Deliberately scoped to a subset of the project's ruff
+      # config that is already clean across src/ and tests/, so this acts as a
+      # ratchet: it cannot fail unless a change introduces a NEW violation.
+      #   E9    syntax / IO errors
+      #   F63   invalid comparisons
+      #   F7    misplaced statements (break outside loop, etc.)
+      #   C4    comprehension misuse
+      #   E711-E714, E731, E741  comparison and naming correctness
+      # F82 (undefined names) is not included yet: there is one pre-existing
+      # F821 in src/yank/common/chunked_transfer.py. Add F82 here once fixed -
+      # it is the highest-value rule in the set.
+      - name: Lint with ruff (blocking subset)
+        run: ruff check src tests --select E9,F63,F7,C4,E711,E712,E713,E714,E731,E741
+
+      # ---------------------------------------------------------------------
+      # Advisory steps below. These are `continue-on-error: true` on purpose:
+      # the codebase has never been linted, formatted or type-checked, so
+      # hard-gating any of them would fail every PR on day one. They run so the
+      # debt stays visible in the logs. Promote each to blocking (drop the
+      # continue-on-error line) once its backlog reaches zero. As of this
+      # workflow landing: ruff 337, black 38 of 42 files, mypy 167 errors.
+      # ---------------------------------------------------------------------
+
+      - name: Lint with ruff, full rule set (advisory)
+        continue-on-error: true
+        run: ruff check src tests
+
+      - name: Check formatting with black (advisory)
+        continue-on-error: true
+        run: black --check src tests
+
+      - name: Type-check with mypy (advisory)
+        continue-on-error: true
+        run: mypy src


### PR DESCRIPTION
Adds `.github/workflows/ci.yml`. There is currently **no PR gate at all** — `release.yml` triggers only on push to `master` and `v*` tags, so nothing runs pytest, ruff, black or mypy on a pull request, and the `dev` extra is never installed in CI. The only thing a push to master verifies today is that PyInstaller can produce a binary.

## What it gates

Triggers on `pull_request` and on push to `master`. Matrix of `macos-latest` / `windows-latest`, Python 3.12 (matching `release.yml`), installing `.[dev,macos]` / `.[dev,windows]` per runner. `concurrency` cancels superseded PR runs but lets master pushes finish. 15-minute job timeout.

| Step | Blocking? |
|---|---|
| `pytest` | yes |
| `ruff check src tests --select E9,F63,F7,C4,E711,E712,E713,E714,E731,E741` | yes |
| `ruff check src tests` (full config rule set) | advisory |
| `black --check src tests` | advisory |
| `mypy src` | advisory |

## Verified end-to-end on real runners

This workflow ran on its own PR, so both legs are proven rather than assumed. **Run: both jobs green.**

| | macOS | Windows |
|---|---|---|
| `pytest` | 87 passed | 82 passed, 5 deselected |
| ruff (blocking subset) | All checks passed | All checks passed |
| ruff (advisory) | 337 errors | 337 errors |
| black (advisory) | 38 of 42 would reformat | 38 of 42 would reformat |
| mypy (advisory) | 167 errors / 20 files | 165 errors / 19 files |

Job conclusion is `success` on both despite the advisory failures — `continue-on-error` works as intended, so the debt is visible in the logs without blocking anyone.

Locally (macOS 15 arm64, Python 3.12.13, `uv venv` + `uv pip install -e ".[dev,macos]"`) the same commands give: pytest 87 passed exit 0; `ruff check src tests` **337 errors exit 1**; black 38/42 exit 1; mypy 167 errors exit 1.

Coverage is 24%, but `pyproject` sets no `--cov-fail-under`, so coverage cannot fail the run. `pytest-cov` is required because `addopts` hardcodes `--cov=yank`; the `dev` extra supplies it.

## The Windows leg caught a real bug on its first run

The first run of this PR was **green on macOS, red on Windows**: 82 passed, **5 errors**.

```
AttributeError: module 'os' has no attribute 'getuid'
src\yank\platform\macos\service.py:29: AttributeError
```

`tests/unit/test_service_status.py::TestMacOSHomebrewDetection` has no platform skip guard, so it runs on Windows; its setup constructs `MacOSServiceManager`, which calls `os.getuid()` — Unix-only. This is a **test-suite portability bug, not a CI bug**, and it would have red-gated every PR on the Windows leg.

Editing `tests/` is out of scope for this change, so the Windows matrix entry deselects that class, with the reason and removal criteria in a comment:

```yaml
pytest_args: '--deselect tests/unit/test_service_status.py::TestMacOSHomebrewDetection'
```

I verified `--deselect` **no-ops on an unmatched nodeid** (87 passed, no error), so this is not a future landmine — it can sit there harmlessly until someone adds `@pytest.mark.skipif(sys.platform != "darwin")` to the class, at which point the flag should be deleted. Worth filing as a follow-up issue.

## Why full ruff is not blocking

`ruff check src tests` **fails today with 337 errors**, so a blocking full-ruff step would red-gate every PR including the bug-fix PRs currently in flight. Breakdown:

```
197 W293  blank-line-with-whitespace       17 E722  bare-except
 55 F401  unused-import                    14 F541  f-string-missing-placeholders
 40 I001  unsorted-imports                  3 B904  raise-without-from-inside-except
  3 F841  unused-variable                   2 B007  unused-loop-control-variable
  2 B017  assert-raises-exception           1 F402  import-shadowed-by-loop-var
  1 F811  redefined-while-unused            1 F821  undefined-name
  1 W291  trailing-whitespace
```

These are spread across the whole tree (136 in `src/yank/*.py`, 96 in `platform/windows`, 76 in `platform/macos`, 22 in `tests`), so they cannot be dodged by excluding a directory. I deliberately did **not** fix any of them — out of scope for this unit, and it would collide with the other in-flight PRs.

Instead of dropping ruff entirely, the blocking step is **scoped to a subset that is already clean** (verified exit 0 locally and on both runners): syntax/IO errors (`E9`), invalid comparisons (`F63`), misplaced statements (`F7`), comprehension misuse (`C4`), and comparison/naming correctness (`E711`-`E714`, `E731`, `E741`). This is a genuine ratchet — it can only fail if a change introduces a *new* violation — while the full rule set still runs advisory.

One deliberate omission: **`F82` (undefined names) is excluded**, because there is one pre-existing violation:

```
src/yank/common/chunked_transfer.py:397:7: F821 Undefined name `TransferMetadata`
```

That is a real latent `NameError` not covered by any of issues #9-#18. Once fixed, `F82` should be added to the blocking select list — it is the highest-value rule in the set. Noted in a comment in the workflow.

## Why black and mypy are advisory

The codebase has never been formatted or type-checked. Hard-gating either would fail every single PR on day one (38/42 files unformatted; ~167 mypy errors, mostly implicit-`Optional` defaults and `Item "None" of "X | None" has no attribute`). Both run with `continue-on-error: true` and a comment stating they are advisory for now and should be promoted to blocking once the backlog is clear. Current counts are recorded in the workflow so the promotion criteria are concrete.

## Why there is no Linux job

`src/yank/platform/linux/` is knowingly broken and out of scope — per `CLAUDE.md` the Linux monitor still takes the older `on_image_copied`/`enable_images` signature, so `ClipboardMonitor(...)` in `ClipboardSync.start()` does not match it. An `ubuntu-latest` leg would fail immediately and block every PR, and would drag in the GTK/gobject-introspection apt preamble that `release.yml` needs. Called out in a comment so nobody "helpfully" adds it back.

## Known follow-up (not fixed here)

`ruff` emits this on every run today:

```
warning: The top-level linter settings are deprecated in favour of their counterparts
in the `lint` section. Please update the following options in pyproject.toml:
  - 'ignore' -> 'lint.ignore'
  - 'select' -> 'lint.select'
```

`pyproject.toml` still uses top-level `[tool.ruff] select`/`ignore`, and the `dev` extra pins only `ruff>=0.1.0`, so CI always resolves the newest ruff. If a future ruff turns that deprecation into a hard error, both ruff steps break — including the blocking one. Moving those two keys under `[tool.ruff.lint]` is a one-line fix, but I left `pyproject.toml` untouched to avoid conflicting with the other in-flight PRs.

Separately, GitHub now warns that `actions/checkout@v4` and `actions/setup-python@v5` target the deprecated Node 20. I kept those pins to match `release.yml`; bumping both workflows to `@v5`/`@v6` is a good follow-up.

## Safety

One new file; nothing under `src/` or `tests/` is touched. No service was installed/started/stopped, `test_service_e2e.py` was never run, no pasteboard write, no bind on 9876/9877, no tag created.
