### PR TITLE
Make console and log output encoding-safe on Windows

### DIFF
--- a/src/yank/common/chunked_transfer.py
+++ b/src/yank/common/chunked_transfer.py
@@ -359,7 +359,7 @@ class ProgressTracker:
         # Progress bar
         bar_width = 20
         filled = int(bar_width * percent / 100)
-        bar = '█' * filled + '░' * (bar_width - filled)
+        bar = '#' * filled + '-' * (bar_width - filled)
 
         return f"[{bar}] {percent:.1f}% ({transferred}/{total}) - {speed} - ETA: {eta}"
 

--- a/src/yank/main.py
+++ b/src/yank/main.py
@@ -62,12 +62,24 @@ else:
     sys.exit(1)
 
 # Setup logging
+#
+# Log records carry arbitrary clipboard text and filenames, so the log file must be
+# opened with an explicit encoding. Without one, Python uses the locale codepage --
+# cp1252 on most Windows installs -- and any emoji, CJK character or curly quote
+# makes the write fail, losing the record. "errors" additionally tolerates the lone
+# surrogates that Windows filenames can carry, which even UTF-8 rejects; it was only
+# added to FileHandler in Python 3.9 and this package supports 3.8.
+if sys.version_info >= (3, 9):
+    _log_file_handler = logging.FileHandler(config.LOG_FILE, encoding="utf-8", errors="replace")
+else:
+    _log_file_handler = logging.FileHandler(config.LOG_FILE, encoding="utf-8")
+
 logging.basicConfig(
     level=getattr(logging, config.LOG_LEVEL),
     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
     handlers=[
         logging.StreamHandler(sys.stdout),
-        logging.FileHandler(config.LOG_FILE)
+        _log_file_handler
     ]
 )
 logger = logging.getLogger(__name__)
@@ -287,7 +299,7 @@ class ClipboardSync:
         text_size = len(text.encode('utf-8'))
         if text_size > self.user_config.max_text_size:
             logger.warning(f"Text too large ({format_size(text_size)}), ignoring")
-            print(f"⚠ Text too large ({format_size(text_size)}). Max: {format_size(self.user_config.max_text_size)}")
+            print(f"! Text too large ({format_size(text_size)}). Max: {format_size(self.user_config.max_text_size)}")
             return
 
         logger.info(f"Sending text to peer ({len(text)} chars)...")

--- a/tests/unit/test_output_encoding.py
+++ b/tests/unit/test_output_encoding.py
@@ -1,0 +1,415 @@
+"""
+Tests for encoding-safe console and log output (issue #12).
+
+On Windows the background service's stdout/stderr are redirected to a file opened
+with the locale codepage (cp1252 on most installs), and the logging FileHandler was
+opened the same way. The app then writes arbitrary clipboard text and filenames to
+those streams, so any emoji, CJK character or curly quote blew up the write.
+
+Two separate failure modes are covered here:
+
+* ``print()`` raises ``UnicodeEncodeError`` straight into its caller. Because the
+  affected prints sit inside receive callbacks, that propagates into the protocol
+  loop -- this is why the bug is not cosmetic.
+* ``logging`` swallows the same error inside ``Handler.handleError`` but *drops the
+  record* and dumps a traceback on stderr, so diagnostics are silently lost.
+
+The fix is to keep every string literal that can reach an output stream pure ASCII,
+and to open the log file as UTF-8 regardless of the machine's locale.
+"""
+
+import ast
+import io
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+
+from yank import config
+from yank.common.chunked_transfer import ProgressTracker
+
+# Source tree under test. Resolved from the repo layout, falling back to the
+# installed package location.
+_SRC_ROOT = Path(__file__).resolve().parents[2] / "src" / "yank"
+if not _SRC_ROOT.is_dir():  # pragma: no cover - only hit for non-editable installs
+    import yank
+
+    _SRC_ROOT = Path(yank.__file__).resolve().parent
+
+# Methods whose arguments end up on an output stream.
+_LOG_METHODS = frozenset(
+    {"debug", "info", "warning", "warn", "error", "exception", "critical", "log"}
+)
+
+
+def _is_output_call(node):
+    """True if ``node`` is a call that writes to a console or the log file.
+
+    Matches ``print(...)``, ``<anything>.debug/info/warning/... (...)`` and
+    ``<anything>.write(...)`` (covers ``sys.stdout.write``). Matching on the
+    attribute name alone deliberately over-approximates: ``logger.info``,
+    ``self.logger.info`` and ``logging.info`` all count, and a false positive
+    only ever asks for one more ASCII string.
+    """
+    func = node.func
+    if isinstance(func, ast.Name):
+        return func.id == "print"
+    if isinstance(func, ast.Attribute):
+        return func.attr in _LOG_METHODS or func.attr == "write"
+    return False
+
+
+def _non_ascii_string_literals(tree):
+    """Yield (lineno, text) for non-ASCII str constants inside output calls.
+
+    Walking the AST rather than grepping the file is the whole point: comments
+    and docstrings are *allowed* to contain non-ASCII (source is decoded as
+    UTF-8 regardless, and neither is ever written to a stream), so a plain text
+    search would flag the box-drawing diagram in ``common/protocol.py`` and the
+    ``--`` section rules in the service modules. Comments never appear in the
+    AST at all, and a docstring is a bare ``Expr`` rather than a ``Call``
+    argument, so both drop out naturally.
+
+    f-strings are covered too: ``JoinedStr`` holds its literal chunks as plain
+    ``Constant`` children, which ``ast.walk`` reaches.
+
+    Known blind spot: a literal bound to a name first (``msg = "⚠ x"`` then
+    ``print(msg)``) is not detected, since only constants lexically inside the
+    call are inspected. No such indirection exists in the package today, and
+    catching it would need dataflow analysis; the runtime cp1252 assertions in
+    TestProgressBarIsAscii cover the rendered output for the one place that
+    builds its string in a helper.
+    """
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not _is_output_call(node):
+            continue
+        for child in ast.walk(node):
+            if isinstance(child, ast.Constant) and isinstance(child.value, str):
+                if not child.value.isascii():
+                    yield getattr(child, "lineno", node.lineno), child.value
+
+
+def _python_sources():
+    return sorted(p for p in _SRC_ROOT.rglob("*.py"))
+
+
+class TestNoNonAsciiInOutputStrings:
+    """Regression guard: non-ASCII must not creep back into printed/logged text."""
+
+    def test_source_tree_is_scannable(self):
+        """Sanity-check the scanner is actually pointed at the package."""
+        sources = _python_sources()
+        assert sources, f"no Python sources found under {_SRC_ROOT}"
+        assert (_SRC_ROOT / "main.py") in sources
+
+    def test_no_non_ascii_in_printed_or_logged_literals(self):
+        offenders = []
+        for path in _python_sources():
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+            for lineno, text in _non_ascii_string_literals(tree):
+                bad = sorted({c for c in text if not c.isascii()})
+                rendered = ", ".join(f"U+{ord(c):04X} {c!r}" for c in bad)
+                offenders.append(f"{path.relative_to(_SRC_ROOT.parent)}:{lineno}: {rendered}")
+
+        assert not offenders, (
+            "Non-ASCII characters found in strings that reach an output stream.\n"
+            "These raise UnicodeEncodeError on a cp1252 Windows console (see #12).\n"
+            "Use the ASCII markers the rest of the CLI uses ('>>', 'X', '!', '[OK]').\n"
+            + "\n".join(offenders)
+        )
+
+    def test_scanner_rejects_a_non_ascii_print(self):
+        """The scanner must actually catch a bad literal (guards against a no-op test)."""
+        tree = ast.parse('print("⚠ warning")\nlogger.info(f"café {x}")\n')
+        found = list(_non_ascii_string_literals(tree))
+        assert len(found) == 2
+
+    def test_scanner_ignores_comments_and_docstrings(self):
+        """Non-ASCII outside output calls is fine and must not be flagged."""
+        source = (
+            '"""Module docstring with a box: ┌─┐."""\n'
+            "# section rule ─── and an em dash —\n"
+            'BANNER = "█ not printed here"\n'
+            'print("plain ascii")\n'
+        )
+        assert list(_non_ascii_string_literals(ast.parse(source))) == []
+
+
+class TestProgressBarIsAscii:
+    """The chunked-transfer progress bar used U+2588/U+2591 block characters."""
+
+    @pytest.mark.parametrize("percent", [0, 1, 37, 99, 100])
+    def test_progress_string_is_ascii(self, percent):
+        tracker = ProgressTracker(total_bytes=1000)
+        tracker.start("file.bin")
+        tracker.update(percent * 10)
+
+        rendered = tracker.get_progress_string()
+        assert rendered.isascii(), f"non-ASCII in progress bar: {rendered!r}"
+
+    def test_progress_bar_uses_hash_and_dash(self):
+        """Must match the equivalent bar rendered in main.py's _on_transfer_progress."""
+        tracker = ProgressTracker(total_bytes=100)
+        tracker.start("file.bin")
+        tracker.update(50)
+
+        bar = tracker.get_progress_string().split("]")[0].split("[")[1]
+        assert set(bar) <= {"#", "-"}, f"unexpected bar characters: {bar!r}"
+        assert "#" in bar and "-" in bar
+
+    def test_progress_string_survives_cp1252(self):
+        """End-to-end: the rendered bar must encode on a cp1252 console."""
+        tracker = ProgressTracker(total_bytes=100)
+        tracker.start("file.bin")
+        tracker.update(50)
+
+        # Raises UnicodeEncodeError if the block characters ever come back.
+        tracker.get_progress_string().encode("cp1252")
+
+
+class TestLogFileHandlerEncoding:
+    """The log FileHandler must be opened as UTF-8, not the locale codepage.
+
+    Note on why these are mostly *source* assertions rather than runtime ones:
+    ``logging.FileHandler`` with no ``encoding`` resolves it through
+    ``io.text_encoding(None)``, i.e. to the locale encoding. macOS and modern
+    Linux always report UTF-8, so ``handler.encoding`` reads back as ``'utf-8'``
+    whether or not the argument was passed -- a runtime check cannot tell fixed
+    from unfixed anywhere except an actual cp1252 Windows host. Asserting on the
+    call site is therefore the only assertion that can fail in CI, so that is
+    where the regression guard lives.
+    """
+
+    @staticmethod
+    def _file_handler_calls():
+        """Every ``logging.FileHandler(...)`` call site in main.py, as AST nodes."""
+        source = (_SRC_ROOT / "main.py").read_text(encoding="utf-8")
+        calls = []
+        for node in ast.walk(ast.parse(source)):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", "")
+            if name == "FileHandler":
+                calls.append(node)
+        return source, calls
+
+    def test_log_file_handler_is_constructed_with_utf8(self):
+        """The actual regression guard: every FileHandler passes encoding='utf-8'."""
+        _, calls = self._file_handler_calls()
+        assert calls, "no logging.FileHandler call found in yank/main.py"
+
+        for call in calls:
+            kwargs = {kw.arg: kw for kw in call.keywords}
+            assert "encoding" in kwargs, (
+                f"FileHandler at main.py:{call.lineno} passes no encoding. On Windows "
+                "that means the locale codepage (cp1252) and any emoji/CJK log record "
+                "is dropped -- see #12."
+            )
+            value = kwargs["encoding"].value
+            assert (
+                isinstance(value, ast.Constant) and value.value == "utf-8"
+            ), f"FileHandler at main.py:{call.lineno} must use encoding='utf-8'"
+
+    def test_errors_kwarg_stays_behind_a_version_guard(self):
+        """The 3.9+ 'errors' kwarg must not break Python 3.8.
+
+        yank/main.py configures logging at import time, so an unsupported keyword
+        would raise TypeError before the CLI can run at all on the declared floor.
+        """
+        source, calls = self._file_handler_calls()
+        using_errors = [c.lineno for c in calls if any(kw.arg == "errors" for kw in c.keywords)]
+
+        if using_errors:
+            assert "sys.version_info >= (3, 9)" in source, (
+                f"FileHandler(errors=...) at line(s) {using_errors} needs a "
+                "sys.version_info >= (3, 9) guard; the kwarg does not exist on 3.8"
+            )
+            # ...and a plain 3.8-compatible fallback must exist alongside it.
+            assert len(calls) >= 2, (
+                "the version-guarded FileHandler needs a Python 3.8 fallback branch "
+                "that omits 'errors'"
+            )
+
+    @staticmethod
+    def _log_file_handlers():
+        """Every FileHandler currently pointed at config.LOG_FILE.
+
+        Importing yank.main is what configures logging; it is already imported by
+        the time the suite runs, so inspect the live configuration rather than
+        re-importing (which would re-run module-level platform setup).
+        """
+        import yank.main  # noqa: F401  - ensures logging.basicConfig has run
+
+        target = str(Path(config.LOG_FILE).resolve())
+        candidates = list(logging.getLogger().handlers)
+        # pytest's logging plugin can swap out the root handlers, so also consult
+        # the handler object main.py built.
+        module_handler = getattr(yank.main, "_log_file_handler", None)
+        if module_handler is not None:
+            candidates.append(module_handler)
+
+        return [
+            h
+            for h in candidates
+            if isinstance(h, logging.FileHandler) and str(Path(h.baseFilename).resolve()) == target
+        ]
+
+    def test_log_file_handler_exists(self):
+        assert self._log_file_handlers(), (
+            f"no FileHandler configured for {config.LOG_FILE}; "
+            "logging setup in yank/main.py may have changed"
+        )
+
+    def test_configured_handler_reports_utf8(self):
+        """Smoke check on the live configuration.
+
+        This cannot fail on a UTF-8-locale host even without the fix (see the
+        class docstring); it exists to catch the handler being reconfigured to
+        something actively wrong, e.g. an explicit non-UTF-8 encoding.
+        """
+        for handler in self._log_file_handlers():
+            assert (
+                handler.encoding == "utf-8"
+            ), f"log FileHandler encoding is {handler.encoding!r}, expected 'utf-8'"
+            if handler.stream is not None:
+                assert handler.stream.encoding.lower().replace("-", "") == "utf8"
+
+    @pytest.mark.skipif(
+        sys.version_info < (3, 9),
+        reason="FileHandler gained the 'errors' parameter in Python 3.9",
+    )
+    def test_configured_handler_replaces_undecodable_characters(self):
+        """Lone surrogates from Windows filenames are rejected even by UTF-8."""
+        for handler in self._log_file_handlers():
+            assert handler.errors == "replace"
+
+    def test_handler_kwargs_are_valid_on_this_interpreter(self, tmp_path):
+        """Re-issue main.py's FileHandler call against a temp file.
+
+        main.py builds the handler at import time, so an invalid keyword would be
+        an immediate TypeError at startup rather than a deferred failure. Rebuild
+        it here instead of reloading yank.main, which would re-run module-level
+        platform setup and swap out class objects other tests hold references to.
+        """
+        log_path = tmp_path / "probe.log"
+        if sys.version_info >= (3, 9):
+            handler = logging.FileHandler(log_path, encoding="utf-8", errors="replace")
+        else:  # pragma: no cover - only exercised on the 3.8 floor
+            handler = logging.FileHandler(log_path, encoding="utf-8")
+        try:
+            assert handler.encoding == "utf-8"
+        finally:
+            handler.close()
+
+
+class TestCp1252StreamRoundTrip:
+    """Reproduce the underlying platform failure on any OS.
+
+    io.TextIOWrapper with encoding='cp1252' behaves exactly like the redirected
+    stdout/log file the Windows service opens, so these run on macOS and Linux.
+    """
+
+    # Content that cp1252 genuinely cannot represent. Note that curly quotes are
+    # *not* in this list: U+201C/U+201D do exist in cp1252 (0x93/0x94). They still
+    # break on other Windows codepages such as cp437, which is precisely why the
+    # CLI's own markers must be ASCII rather than merely "cp1252-safe" -- see
+    # test_curly_quotes_depend_on_the_active_codepage below.
+    SAMPLES = [
+        "emoji \U0001f600",
+        "cjk 漢字",
+        "warning sign ⚠",
+        "block █░",
+    ]
+
+    @staticmethod
+    def _stream(encoding, errors="strict"):
+        return io.TextIOWrapper(io.BytesIO(), encoding=encoding, errors=errors)
+
+    @pytest.mark.parametrize("text", SAMPLES)
+    def test_cp1252_stream_rejects_non_ascii(self, text):
+        """Baseline: this is the exact production failure."""
+        stream = self._stream("cp1252")
+        with pytest.raises(UnicodeEncodeError):
+            print(text, file=stream)
+            stream.flush()
+
+    @pytest.mark.parametrize("text", SAMPLES)
+    def test_utf8_stream_accepts_non_ascii(self, text):
+        """The configured encoding handles the same content fine."""
+        stream = self._stream("utf-8")
+        print(text, file=stream)
+        stream.flush()
+
+    def test_curly_quotes_depend_on_the_active_codepage(self):
+        """Which characters survive depends on the machine's locale.
+
+        cp1252 happens to include curly quotes, cp437 (still the default OEM
+        console codepage in some locales) does not. Since the app cannot know
+        the codepage of the console it is attached to, ASCII-only output is the
+        only portable answer for CLI markers.
+        """
+        # TextIOWrapper encodes eagerly on write(), so these are real assertions.
+        ok = self._stream("cp1252")
+        ok.write("“hello”")  # fine here...
+        ok.flush()
+
+        bad = self._stream("cp437")
+        with pytest.raises(UnicodeEncodeError):  # ...but not here
+            bad.write("“hello”")
+            bad.flush()
+
+    def test_utf8_alone_still_rejects_lone_surrogates(self):
+        """Why errors='replace' is warranted on top of encoding='utf-8'."""
+        strict = self._stream("utf-8")
+        with pytest.raises(UnicodeEncodeError):
+            strict.write("windows \udcff filename")
+            strict.flush()
+
+        lenient = self._stream("utf-8", errors="replace")
+        lenient.write("windows \udcff filename")
+        lenient.flush()
+
+    def test_file_handler_writes_non_ascii_record_through_configured_encoding(self, tmp_path):
+        """A FileHandler built the way main.py builds it keeps the record.
+
+        Without an explicit encoding this same record is silently dropped on a
+        cp1252 machine: logging catches the UnicodeEncodeError in handleError,
+        so nothing propagates but the diagnostic is lost.
+        """
+        log_path = tmp_path / "sync.log"
+        handler = logging.FileHandler(log_path, encoding="utf-8")
+        logger = logging.getLogger("yank.tests.encoding")
+        logger.propagate = False
+        logger.setLevel(logging.INFO)
+        logger.addHandler(handler)
+        try:
+            logger.info("copied file \U0001f600 漢字.txt")
+        finally:
+            logger.removeHandler(handler)
+            handler.close()
+
+        contents = log_path.read_text(encoding="utf-8")
+        assert "\U0001f600" in contents
+        assert "漢字.txt" in contents
+
+    def test_cp1252_file_handler_drops_the_record(self, tmp_path):
+        """Documents the pre-fix behaviour the encoding argument prevents."""
+        log_path = tmp_path / "sync-cp1252.log"
+        handler = logging.FileHandler(log_path, encoding="cp1252")
+        logger = logging.getLogger("yank.tests.encoding.cp1252")
+        logger.propagate = False
+        logger.setLevel(logging.INFO)
+        logger.addHandler(handler)
+
+        previous = logging.raiseExceptions
+        logging.raiseExceptions = False  # suppress the handleError traceback on stderr
+        try:
+            logger.info("copied file \U0001f600.txt")
+        finally:
+            logging.raiseExceptions = previous
+            logger.removeHandler(handler)
+            handler.close()
+
+        assert log_path.read_text(encoding="cp1252") == ""


### PR DESCRIPTION
Fixes the console and log-handler half of #12. (Not `Closes` — the Windows service log handle in `src/yank/platform/windows/service.py` is the other half and is being handled separately.)

## The bug

The background service redirects stdout/stderr to a file opened with the locale codepage (cp1252 on most Windows installs), and the logging `FileHandler` was opened the same way. The app writes arbitrary clipboard text and filenames to both, so any emoji, CJK character, or other non-representable content breaks the write.

While writing the tests I confirmed the two failure modes are **not** equivalent:

| Path | Behaviour on unencodable content |
|---|---|
| `print(...)` | `UnicodeEncodeError` propagates **into the caller** |
| `logger.info(...)` | swallowed by `Handler.handleError`, but the **record is dropped** and a traceback is dumped on stderr |

So the crash path — the one that trips the double-ACK protocol desync in #10 — is `print()`, not logging. The log-handler change fixes silent diagnostic loss, which matters most precisely when you are debugging a transfer that failed on a non-ASCII filename.

## Changes

**`src/yank/main.py`**
- Log `FileHandler` now passes `encoding="utf-8"` instead of inheriting the locale codepage.
- Replaced the `⚠` (U+26A0) marker in the "text too large" message with `!`, matching every sibling message in the same method (and the CLI's deliberate ASCII convention: `>>`, `X`, `!`, `[OK]`).

**`src/yank/common/chunked_transfer.py`**
- `ProgressTracker.get_progress_string()` renders with `#`/`-` instead of `█`/`░` (U+2588/U+2591), matching the equivalent bar `main.py` already draws in `_on_transfer_progress`.

### On `errors="replace"` — yes, but version-guarded

Warranted: `encoding="utf-8"` alone still raises on **lone surrogates**, which Windows filenames can carry (surrogatepass) and which reach the logger via filename interpolation. Verified:

```
utf-8/strict:  UnicodeEncodeError
utf-8/replace: ok
```

A mangled character in a log file is strictly better than a dropped record.

But `FileHandler` only gained `errors` in **Python 3.9**, and `pyproject.toml` declares `requires-python = ">=3.8"` (with mypy/ruff/black all pinned to a py38 floor). Since `logging.basicConfig` runs at **module import time**, passing it unconditionally would be a hard `TypeError` at startup on 3.8 — not a deferred failure. Hence the guard:

```python
if sys.version_info >= (3, 9):
    _log_file_handler = logging.FileHandler(config.LOG_FILE, encoding="utf-8", errors="replace")
else:
    _log_file_handler = logging.FileHandler(config.LOG_FILE, encoding="utf-8")
```

Import-time behaviour is otherwise unchanged: the handler is still constructed once, still points at `config.LOG_FILE`, and `config.py` still creates `TEMP_DIR` on import.

## Scope check

I grepped all of `src/` for non-ASCII. Besides the two fixed sites, every remaining occurrence is a `# ──` section rule in the `*/service.py` files, the box-drawing diagram in `common/protocol.py`'s module docstring, or generated `egg-info`. None of those ever reach an output stream — source files are decoded as UTF-8 regardless — so they are deliberately left alone.

## Tests — `tests/unit/test_output_encoding.py` (29 tests)

1. **AST-based regression scan.** Walks every module under `src/yank/` for `Call` nodes to `print` / `logger.*` / `.write` and flags non-ASCII string constants in their arguments (f-string chunks included). A whole-file grep would false-positive on exactly the comments and docstrings above, which is the distinction the fix depends on — comments never enter the AST, and docstrings are bare `Expr` nodes rather than call arguments. Two meta-tests assert the scanner both catches a planted bad literal and ignores comments/docstrings, so it cannot silently become a no-op. Known blind spot (documented inline): a literal bound to a name before being printed isn't traced.
2. **FileHandler construction**, asserted at the call site plus a Python-3.8-compatibility check on the `errors` guard — see the caveat below.
3. **cp1252/cp437 round-trips** reproducing the real failure on macOS via `io.TextIOWrapper`, including a direct demonstration that a cp1252 `FileHandler` drops a record that a utf-8 one keeps.

### Caveat worth knowing for future reviewers

My first draft asserted `handler.encoding == "utf-8"` at runtime. **That test passed even with the fix reverted.** `FileHandler` with no `encoding` resolves it via `io.text_encoding(None)` → the locale encoding, and macOS always reports UTF-8 — so a runtime check cannot distinguish fixed from unfixed anywhere except an actual cp1252 host. The real guard is therefore asserted against the **call site in the source**, and the runtime check is retained only as a labelled smoke test. This is documented in the test class docstring so nobody "simplifies" it back.

Similarly, my initial sample list included a curly quote as cp1252-unencodable — the test proved otherwise (U+201C *is* cp1252 0x93). It's now used to make the sharper point that which characters survive is codepage-dependent, so ASCII-only is the only portable answer.

## Verification

- Full suite: **116 passed** (87 baseline + 29 new).
- Reverting each half of the fix was confirmed to fail the suite (8 tests for the glyphs, 2 for the FileHandler); restoring returns it to green.
- `ruff` and `black` clean on the new test file. `mypy src` reports **167 errors before and after** — all pre-existing and untouched; the 2 black-unformatted source files were likewise already unformatted on master, so I left them rather than churn regions other work is touching.
- No e2e run: per the coordinator this is unsafe on a shared machine, and the failure only reproduces natively on a Windows host. The cp1252 round-trip tests reproduce it faithfully on any platform instead.
