### PR TITLE
Fix macOS clipboard echo loop by splitting file and image hashes

### DIFF
--- a/src/yank/platform/macos/clipboard.py
+++ b/src/yank/platform/macos/clipboard.py
@@ -92,9 +92,22 @@ class MacClipboardMonitor:
         self._running = False
         self._monitor_thread: Optional[threading.Thread] = None
         self._last_change_count: int = 0
-        self._last_content_hash: Optional[str] = None
+        # One hash per kind of clipboard content. These MUST stay separate: a
+        # file-list hash and an image-data hash are drawn from different
+        # domains, so comparing one against the other never matches and the
+        # de-duplication silently degrades into an echo loop (an injected image
+        # file gets re-sent to the peer as a fresh image copy).
+        self._last_file_hash: Optional[str] = None
+        self._last_image_hash: Optional[str] = None
         self._last_text_hash: Optional[str] = None
         self._lock = threading.Lock()
+
+        # Serialises "write to the pasteboard, then record its changeCount"
+        # against the monitor thread's "read changeCount, then record it".
+        # Without it the poller can observe an injection mid-write and treat it
+        # as a fresh user copy. Re-entrant because set_clipboard_files() ->
+        # _set_clipboard_image_file() -> _set_clipboard_files_only() nests.
+        self._pasteboard_lock = threading.RLock()
 
         # Track files/text we've received to avoid loops
         self._received_files: set = set()
@@ -111,8 +124,9 @@ class MacClipboardMonitor:
             return
         
         # Initialize change count
-        self._last_change_count = self._pasteboard.changeCount()
-        
+        with self._pasteboard_lock:
+            self._last_change_count = self._pasteboard.changeCount()
+
         self._running = True
         self._monitor_thread = threading.Thread(target=self._monitor_loop, daemon=True)
         self._monitor_thread.start()
@@ -137,24 +151,35 @@ class MacClipboardMonitor:
     
     def _check_clipboard(self):
         """Check clipboard for file, image, or text changes"""
-        # Check if clipboard changed
-        current_count = self._pasteboard.changeCount()
+        # Sample the pasteboard while holding the injection lock. set_clipboard_*
+        # holds the same lock across "write, then record the new changeCount", so
+        # the poller either runs entirely before the write (and sees the old
+        # count) or entirely after it (and sees a count that already matches
+        # _last_change_count). Either way an injected item is never mistaken for
+        # a fresh user copy.
+        with self._pasteboard_lock:
+            # Check if clipboard changed
+            current_count = self._pasteboard.changeCount()
 
-        if current_count == self._last_change_count:
-            return
+            if current_count == self._last_change_count:
+                return
 
-        # Get available types
-        types = self._pasteboard.types()
+            # Get available types
+            types = self._pasteboard.types()
 
-        # Re-check change count - if clipboard changed during read, skip this cycle
-        # to avoid processing inconsistent data
-        post_read_count = self._pasteboard.changeCount()
-        if post_read_count != current_count:
-            self._last_change_count = post_read_count
-            return
+            # Re-check change count - if clipboard changed during read, skip this cycle
+            # to avoid processing inconsistent data
+            post_read_count = self._pasteboard.changeCount()
+            if post_read_count != current_count:
+                self._last_change_count = post_read_count
+                return
 
-        self._last_change_count = current_count
+            self._last_change_count = current_count
 
+        # The handlers re-read the pasteboard and then invoke user callbacks
+        # (which send over the network). They run outside the lock so a slow
+        # callback cannot stall an incoming paste; the per-kind content hashes
+        # below are what protect the handlers from acting on an injection.
         # Priority: Files first, then images, then text
         if self.sync_files and NSFilenamesPboardType in types:
             self._handle_files()
@@ -174,10 +199,10 @@ class MacClipboardMonitor:
         file_hash = self._hash_file_list(file_paths)
         
         with self._lock:
-            if file_hash == self._last_content_hash:
+            if file_hash == self._last_file_hash:
                 return
-            self._last_content_hash = file_hash
-        
+            self._last_file_hash = file_hash
+
         # Check if these are files we just received (avoid loops)
         with self._received_files_lock:
             if all(str(p).lower() in self._received_files for p in file_paths):
@@ -207,14 +232,17 @@ class MacClipboardMonitor:
             # Get bytes for hashing
             data_bytes = bytes(image_data)
             
-            # Create hash to detect changes
-            data_hash = hashlib.md5(data_bytes[:4096] if len(data_bytes) > 4096 else data_bytes).hexdigest()
-            
+            # Create hash to detect changes. Hash the whole payload: two
+            # different images that happen to share a leading chunk (same
+            # header, same first rows of pixels) would otherwise collide and
+            # the second one would never be sent.
+            data_hash = self._hash_image_data(data_bytes)
+
             with self._lock:
-                if data_hash == self._last_content_hash:
+                if data_hash == self._last_image_hash:
                     return
-                self._last_content_hash = data_hash
-            
+                self._last_image_hash = data_hash
+
             # Save to temp file
             timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
             filename = f"clipboard_image_{timestamp}.png"
@@ -326,6 +354,16 @@ class MacClipboardMonitor:
         content = '|'.join(sorted(str(p) for p in file_paths))
         return hashlib.md5(content.encode()).hexdigest()
 
+    @staticmethod
+    def _hash_image_data(data: bytes) -> str:
+        """Create a hash of raw image bytes for change detection.
+
+        Compared only against other image hashes (never against a file-list
+        hash), and always over the full payload so distinct images with a
+        common prefix stay distinct.
+        """
+        return hashlib.md5(data).hexdigest()
+
     def set_clipboard_text(self, text: str):
         """
         Set text in the clipboard
@@ -346,9 +384,12 @@ class MacClipboardMonitor:
             self._last_text_hash = text_hash
 
         try:
-            self._pasteboard.clearContents()
-            self._pasteboard.setString_forType_(text, NSPasteboardTypeString)
-            self._last_change_count = self._pasteboard.changeCount()
+            # Write and record the resulting changeCount atomically with respect
+            # to the monitor thread (see _check_clipboard).
+            with self._pasteboard_lock:
+                self._pasteboard.clearContents()
+                self._pasteboard.setString_forType_(text, NSPasteboardTypeString)
+                self._last_change_count = self._pasteboard.changeCount()
             logger.info(f"Set text in clipboard ({len(text)} chars)")
         except Exception as e:
             logger.error(f"Failed to set clipboard text: {e}")
@@ -374,33 +415,34 @@ class MacClipboardMonitor:
         
         # Update our hash to avoid re-sending
         with self._lock:
-            self._last_content_hash = self._hash_file_list(file_paths)
-        
+            self._last_file_hash = self._hash_file_list(file_paths)
+
         # Check if it's a single image file - put as image data too
         if len(file_paths) == 1:
             ext = file_paths[0].suffix.lower()
             if ext in ('.png', '.jpg', '.jpeg', '.gif', '.bmp', '.tiff', '.webp'):
                 self._set_clipboard_image_file(file_paths[0])
                 return
-        
+
         try:
-            # Clear and prepare pasteboard
-            self._pasteboard.clearContents()
-            
-            # Convert paths to filenames
-            filenames = [str(p) for p in file_paths]
-            
-            # Set as filenames (for Finder paste)
-            self._pasteboard.setPropertyList_forType_(
-                NSArray.arrayWithArray_(filenames),
-                NSFilenamesPboardType
-            )
-            
-            # Update change count tracking
-            self._last_change_count = self._pasteboard.changeCount()
-            
+            with self._pasteboard_lock:
+                # Clear and prepare pasteboard
+                self._pasteboard.clearContents()
+
+                # Convert paths to filenames
+                filenames = [str(p) for p in file_paths]
+
+                # Set as filenames (for Finder paste)
+                self._pasteboard.setPropertyList_forType_(
+                    NSArray.arrayWithArray_(filenames),
+                    NSFilenamesPboardType
+                )
+
+                # Update change count tracking
+                self._last_change_count = self._pasteboard.changeCount()
+
             logger.info(f"Set {len(file_paths)} file(s) in clipboard")
-            
+
         except Exception as e:
             logger.error(f"Failed to set clipboard files: {e}")
     
@@ -429,25 +471,35 @@ class MacClipboardMonitor:
                     # Fallback: just set as file
                     self._set_clipboard_files_only([image_path])
                     return
-            
-            # Clear and prepare pasteboard
-            self._pasteboard.clearContents()
-            
-            # Set PNG data for image paste
-            png_ns_data = NSData.dataWithBytes_length_(png_data, len(png_data))
-            self._pasteboard.setData_forType_(png_ns_data, NSPasteboardTypePNG)
-            
-            # Also set as file for file-based paste
-            self._pasteboard.setPropertyList_forType_(
-                NSArray.arrayWithArray_([str(image_path)]),
-                NSFilenamesPboardType
-            )
-            
-            # Update change count tracking
-            self._last_change_count = self._pasteboard.changeCount()
-            
+
+            # Arm BOTH guards before touching the pasteboard. This write puts
+            # image data on the pasteboard as well as a filename, so the next
+            # poll may take either branch depending on the sync_files /
+            # sync_images toggles - recording only the file-list hash here is
+            # what used to let a received image echo straight back to the peer.
+            with self._lock:
+                self._last_file_hash = self._hash_file_list([image_path])
+                self._last_image_hash = self._hash_image_data(png_data)
+
+            with self._pasteboard_lock:
+                # Clear and prepare pasteboard
+                self._pasteboard.clearContents()
+
+                # Set PNG data for image paste
+                png_ns_data = NSData.dataWithBytes_length_(png_data, len(png_data))
+                self._pasteboard.setData_forType_(png_ns_data, NSPasteboardTypePNG)
+
+                # Also set as file for file-based paste
+                self._pasteboard.setPropertyList_forType_(
+                    NSArray.arrayWithArray_([str(image_path)]),
+                    NSFilenamesPboardType
+                )
+
+                # Update change count tracking
+                self._last_change_count = self._pasteboard.changeCount()
+
             logger.info(f"Set image in clipboard: {image_path.name}")
-            
+
         except Exception as e:
             logger.error(f"Failed to set clipboard image: {e}")
             # Fall back to file-only
@@ -455,14 +507,20 @@ class MacClipboardMonitor:
     
     def _set_clipboard_files_only(self, file_paths: List[Path]):
         """Set files in clipboard (without image conversion)"""
+        # Arm the file guard here too so this method is safe to call directly
+        # and not only as a fallback from set_clipboard_files().
+        with self._lock:
+            self._last_file_hash = self._hash_file_list(file_paths)
+
         try:
-            self._pasteboard.clearContents()
-            filenames = [str(p) for p in file_paths]
-            self._pasteboard.setPropertyList_forType_(
-                NSArray.arrayWithArray_(filenames),
-                NSFilenamesPboardType
-            )
-            self._last_change_count = self._pasteboard.changeCount()
+            with self._pasteboard_lock:
+                self._pasteboard.clearContents()
+                filenames = [str(p) for p in file_paths]
+                self._pasteboard.setPropertyList_forType_(
+                    NSArray.arrayWithArray_(filenames),
+                    NSFilenamesPboardType
+                )
+                self._last_change_count = self._pasteboard.changeCount()
         except Exception as e:
             logger.error(f"Failed to set clipboard files: {e}")
     

--- a/tests/unit/test_macos_clipboard.py
+++ b/tests/unit/test_macos_clipboard.py
@@ -1,0 +1,546 @@
+"""
+Unit tests for the macOS clipboard monitor.
+
+These tests NEVER touch the real system pasteboard: ``NSPasteboard`` is patched
+out for a ``FakePasteboard`` before the monitor is constructed, so
+``NSPasteboard.generalPasteboard()`` never runs and nothing is written to the
+user's clipboard.
+
+The main thing under test is loop prevention. ``MacClipboardMonitor`` keeps a
+"last seen" hash so that content it injected into the pasteboard (because a peer
+sent it) is not immediately detected as a fresh user copy and sent straight back.
+That hash used to be a single field shared by the file-list path and the
+image-data path, which meant an injected image file stored a file-list hash and
+the next poll - taking the image branch - compared image bytes against it, found
+no match, and echoed the image back to the peer.
+"""
+import sys
+import hashlib
+import threading
+
+import pytest
+
+pytest.importorskip("AppKit", reason="pyobjc is required for the macOS clipboard monitor")
+
+pytestmark = pytest.mark.skipif(
+    sys.platform != "darwin", reason="macOS clipboard monitor is darwin-only"
+)
+
+from AppKit import (  # noqa: E402
+    NSFilenamesPboardType,
+    NSPasteboardTypePNG,
+    NSPasteboardTypeString,
+    NSPasteboardTypeTIFF,
+)
+
+from yank.platform.macos import clipboard as mac_clipboard  # noqa: E402
+from yank.platform.macos.clipboard import MacClipboardMonitor  # noqa: E402
+
+
+# --------------------------------------------------------------------------
+# Fake pasteboard
+# --------------------------------------------------------------------------
+
+
+class FakePasteboard:
+    """In-memory stand-in for NSPasteboard.
+
+    Mirrors the parts of the real semantics the monitor depends on: only
+    ``clearContents`` bumps ``changeCount``, and reads return whatever the last
+    write stored under that type.
+    """
+
+    def __init__(self):
+        self._items = {}
+        self._change_count = 0
+        # Optional callable invoked with the name of each mutating method, used
+        # to pause a write mid-flight in the concurrency test.
+        self.on_write = None
+
+    # -- reads --------------------------------------------------------------
+
+    def changeCount(self):  # noqa: N802 - Cocoa naming
+        return self._change_count
+
+    def types(self):
+        return list(self._items.keys())
+
+    def dataForType_(self, type_):  # noqa: N802
+        return self._items.get(type_)
+
+    def propertyListForType_(self, type_):  # noqa: N802
+        return self._items.get(type_)
+
+    def stringForType_(self, type_):  # noqa: N802
+        return self._items.get(type_)
+
+    def pasteboardItems(self):  # noqa: N802
+        return []
+
+    # -- writes -------------------------------------------------------------
+
+    def _hook(self, name):
+        if self.on_write is not None:
+            self.on_write(name)
+
+    def clearContents(self):  # noqa: N802
+        self._hook("clearContents")
+        self._items.clear()
+        self._change_count += 1
+        return self._change_count
+
+    def setData_forType_(self, data, type_):  # noqa: N802
+        self._hook("setData_forType_")
+        self._items[type_] = bytes(data)
+        return True
+
+    def setPropertyList_forType_(self, plist, type_):  # noqa: N802
+        self._hook("setPropertyList_forType_")
+        self._items[type_] = [str(p) for p in plist]
+        return True
+
+    def setString_forType_(self, string, type_):  # noqa: N802
+        self._hook("setString_forType_")
+        self._items[type_] = str(string)
+        return True
+
+    # -- test helpers -------------------------------------------------------
+
+    def user_copies(self, **by_type):
+        """Simulate some other app putting content on the pasteboard."""
+        self._items.clear()
+        self._items.update(by_type)
+        self._change_count += 1
+
+
+class FakeNSPasteboardClass:
+    """Replaces the NSPasteboard *class* so generalPasteboard() is never called."""
+
+    def __init__(self, board):
+        self._board = board
+
+    def generalPasteboard(self):  # noqa: N802
+        return self._board
+
+
+# --------------------------------------------------------------------------
+# Fixtures / helpers
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture
+def pasteboard(monkeypatch):
+    board = FakePasteboard()
+    monkeypatch.setattr(mac_clipboard, "NSPasteboard", FakeNSPasteboardClass(board))
+    return board
+
+
+@pytest.fixture
+def make_monitor(pasteboard, tmp_path):
+    """Build a monitor wired to the fake pasteboard, plus its callback records."""
+    created = {}
+
+    def factory(**kwargs):
+        kwargs.setdefault("sync_text", True)
+        kwargs.setdefault("sync_files", True)
+        kwargs.setdefault("sync_images", True)
+        monitor = MacClipboardMonitor(
+            on_files_copied=lambda paths: created["files"].append(list(paths)),
+            on_text_copied=lambda text: created["text"].append(text),
+            temp_dir=tmp_path / "spool",
+            **kwargs,
+        )
+        assert monitor._pasteboard is pasteboard
+        return monitor
+
+    created["files"] = []
+    created["text"] = []
+    factory.files_copied = created["files"]
+    factory.text_copied = created["text"]
+    return factory
+
+
+def image_bytes(seed: bytes, size: int = 256) -> bytes:
+    """Deterministic pseudo-image payload (never decoded, only hashed/written)."""
+    out = bytearray()
+    chunk = seed
+    while len(out) < size:
+        chunk = hashlib.sha256(chunk).digest()
+        out.extend(chunk)
+    return bytes(out[:size])
+
+
+IMAGE_A = image_bytes(b"a")
+IMAGE_B = image_bytes(b"b")
+
+
+# --------------------------------------------------------------------------
+# The echo-loop regression
+# --------------------------------------------------------------------------
+
+
+class TestInjectedImageDoesNotEcho:
+    """Regression: a received image must never be sent straight back."""
+
+    def test_injected_image_file_is_not_echoed_when_only_images_sync(
+        self, make_monitor, pasteboard, tmp_path
+    ):
+        # sync_files=False + sync_images=True is the exact configuration that
+        # exposed the bug: set_clipboard_files() stored a FILE-LIST hash, but
+        # the next poll skipped the file branch and hashed the image DATA.
+        monitor = make_monitor(sync_files=False, sync_images=True)
+
+        received = tmp_path / "from_peer.png"
+        received.write_bytes(IMAGE_A)
+
+        count_before = monitor._last_change_count
+        monitor.set_clipboard_files([received])
+
+        # The change-count guard alone would short-circuit the poll, so defeat
+        # it deliberately: this simulates the poller having sampled the
+        # pasteboard before set_clipboard_files() recorded the new count (the
+        # race the injection lock closes), and also covers macOS bumping the
+        # change count again after our write. The per-kind content hash is the
+        # guard that has to catch this case.
+        monitor._last_change_count = count_before
+
+        monitor._check_clipboard()
+
+        assert make_monitor.files_copied == [], "received image was echoed back to the peer"
+
+    def test_injected_image_file_is_not_echoed_when_files_also_sync(
+        self, make_monitor, tmp_path
+    ):
+        monitor = make_monitor(sync_files=True, sync_images=True)
+
+        received = tmp_path / "from_peer.png"
+        received.write_bytes(IMAGE_A)
+
+        count_before = monitor._last_change_count
+        monitor.set_clipboard_files([received])
+        monitor._last_change_count = count_before
+
+        monitor._check_clipboard()
+
+        assert make_monitor.files_copied == []
+
+    def test_injection_arms_both_the_file_and_image_guards(self, make_monitor, tmp_path):
+        monitor = make_monitor()
+
+        received = tmp_path / "from_peer.png"
+        received.write_bytes(IMAGE_A)
+
+        monitor.set_clipboard_files([received])
+
+        # An image injection puts BOTH a filename and image data on the
+        # pasteboard, so both guards must be armed - not just one of them.
+        assert monitor._last_file_hash == monitor._hash_file_list([received])
+        assert monitor._last_image_hash == hashlib.md5(IMAGE_A).hexdigest()
+
+    def test_injected_non_png_image_is_not_echoed(self, make_monitor, pasteboard, tmp_path):
+        """A JPEG is converted to PNG on the way to the pasteboard.
+
+        The image guard therefore has to be armed with the hash of the
+        *converted* bytes, not the bytes of the file on disk.
+        """
+        PIL_Image = pytest.importorskip("PIL.Image")
+
+        monitor = make_monitor(sync_files=False, sync_images=True)
+
+        received = tmp_path / "from_peer.jpg"
+        PIL_Image.new("RGB", (8, 8), (10, 120, 200)).save(received, format="JPEG")
+
+        count_before = monitor._last_change_count
+        monitor.set_clipboard_files([received])
+
+        on_board = pasteboard.dataForType_(NSPasteboardTypePNG)
+        if on_board is None:
+            pytest.skip("NSImage conversion unavailable in this environment")
+
+        # Guard is armed from the converted PNG, which differs from the file.
+        assert monitor._last_image_hash == hashlib.md5(on_board).hexdigest()
+        assert monitor._last_image_hash != hashlib.md5(received.read_bytes()).hexdigest()
+
+        monitor._last_change_count = count_before
+        monitor._check_clipboard()
+
+        assert make_monitor.files_copied == []
+
+    def test_injected_plain_files_are_not_echoed(self, make_monitor, tmp_path):
+        monitor = make_monitor()
+
+        a = tmp_path / "a.txt"
+        a.write_text("hello")
+        b = tmp_path / "b.txt"
+        b.write_text("world")
+
+        count_before = monitor._last_change_count
+        monitor.set_clipboard_files([a, b])
+        monitor._last_change_count = count_before
+
+        monitor._check_clipboard()
+
+        assert make_monitor.files_copied == []
+
+    def test_injected_text_is_not_echoed(self, make_monitor):
+        monitor = make_monitor()
+
+        count_before = monitor._last_change_count
+        monitor.set_clipboard_text("from the peer")
+        monitor._last_change_count = count_before
+
+        monitor._check_clipboard()
+
+        assert make_monitor.text_copied == []
+
+
+# --------------------------------------------------------------------------
+# ...but real copies must still be detected
+# --------------------------------------------------------------------------
+
+
+class TestGenuineCopiesStillFire:
+    """A fix that suppresses everything is not a fix."""
+
+    def test_new_image_fires_the_callback(self, make_monitor, pasteboard):
+        monitor = make_monitor(sync_files=False, sync_images=True)
+
+        pasteboard.user_copies(**{NSPasteboardTypePNG: IMAGE_A})
+        monitor._check_clipboard()
+
+        assert len(make_monitor.files_copied) == 1
+        [saved] = make_monitor.files_copied[0]
+        assert saved.read_bytes() == IMAGE_A
+
+    def test_new_image_fires_even_right_after_an_injection(
+        self, make_monitor, pasteboard, tmp_path
+    ):
+        monitor = make_monitor(sync_files=False, sync_images=True)
+
+        received = tmp_path / "from_peer.png"
+        received.write_bytes(IMAGE_A)
+        monitor.set_clipboard_files([received])
+
+        # The user now copies a genuinely different image.
+        pasteboard.user_copies(**{NSPasteboardTypePNG: IMAGE_B})
+        monitor._check_clipboard()
+
+        assert len(make_monitor.files_copied) == 1
+        [saved] = make_monitor.files_copied[0]
+        assert saved.read_bytes() == IMAGE_B
+
+    def test_tiff_only_image_fires_the_callback(self, make_monitor, pasteboard):
+        monitor = make_monitor(sync_files=False, sync_images=True)
+
+        pasteboard.user_copies(**{NSPasteboardTypeTIFF: IMAGE_A})
+        monitor._check_clipboard()
+
+        assert len(make_monitor.files_copied) == 1
+
+    def test_new_files_fire_the_callback(self, make_monitor, pasteboard, tmp_path):
+        monitor = make_monitor()
+
+        target = tmp_path / "doc.txt"
+        target.write_text("x")
+        pasteboard.user_copies(**{NSFilenamesPboardType: [str(target)]})
+        monitor._check_clipboard()
+
+        assert make_monitor.files_copied == [[target]]
+
+    def test_new_text_fires_the_callback(self, make_monitor, pasteboard):
+        monitor = make_monitor()
+
+        pasteboard.user_copies(**{NSPasteboardTypeString: "typed by the user"})
+        monitor._check_clipboard()
+
+        assert make_monitor.text_copied == ["typed by the user"]
+
+    def test_a_file_copy_does_not_unblock_an_image_and_vice_versa(
+        self, make_monitor, pasteboard, tmp_path
+    ):
+        """The two hashes are independent - neither clobbers the other."""
+        monitor = make_monitor()
+
+        target = tmp_path / "doc.txt"
+        target.write_text("x")
+
+        pasteboard.user_copies(**{NSPasteboardTypeString: "text"})
+        monitor._check_clipboard()
+
+        pasteboard.user_copies(**{NSFilenamesPboardType: [str(target)]})
+        monitor._check_clipboard()
+        file_hash_after = monitor._last_file_hash
+
+        pasteboard.user_copies(**{NSPasteboardTypePNG: IMAGE_A})
+        monitor._check_clipboard()
+
+        # Handling the image left the file hash intact...
+        assert monitor._last_file_hash == file_hash_after
+        # ...and produced a distinct image hash.
+        assert monitor._last_image_hash == hashlib.md5(IMAGE_A).hexdigest()
+        assert monitor._last_image_hash != monitor._last_file_hash
+        assert len(make_monitor.files_copied) == 2
+
+
+# --------------------------------------------------------------------------
+# De-duplication of repeats
+# --------------------------------------------------------------------------
+
+
+class TestDeduplication:
+    def test_same_image_seen_twice_fires_once(self, make_monitor, pasteboard):
+        monitor = make_monitor(sync_files=False, sync_images=True)
+
+        pasteboard.user_copies(**{NSPasteboardTypePNG: IMAGE_A})
+        monitor._check_clipboard()
+        pasteboard.user_copies(**{NSPasteboardTypePNG: IMAGE_A})
+        monitor._check_clipboard()
+
+        assert len(make_monitor.files_copied) == 1
+
+    def test_same_file_list_seen_twice_fires_once(self, make_monitor, pasteboard, tmp_path):
+        monitor = make_monitor()
+
+        target = tmp_path / "doc.txt"
+        target.write_text("x")
+
+        for _ in range(2):
+            pasteboard.user_copies(**{NSFilenamesPboardType: [str(target)]})
+            monitor._check_clipboard()
+
+        assert len(make_monitor.files_copied) == 1
+
+    def test_images_sharing_a_4kb_prefix_are_treated_as_different(
+        self, make_monitor, pasteboard
+    ):
+        """The hash used to cover only the first 4096 bytes."""
+        monitor = make_monitor(sync_files=False, sync_images=True)
+
+        prefix = image_bytes(b"shared-prefix", 8192)
+        first = prefix + b"\x00" * 64
+        second = prefix + b"\xff" * 64
+
+        pasteboard.user_copies(**{NSPasteboardTypePNG: first})
+        monitor._check_clipboard()
+        pasteboard.user_copies(**{NSPasteboardTypePNG: second})
+        monitor._check_clipboard()
+
+        assert len(make_monitor.files_copied) == 2, "second image was hidden by a prefix-only hash"
+        # Note: both spool files can share a name (the temp filename only has
+        # second resolution), so assert on the payload of the latest write.
+        assert make_monitor.files_copied[1][0].read_bytes() == second
+        assert monitor._last_image_hash == hashlib.md5(second).hexdigest()
+
+
+# --------------------------------------------------------------------------
+# The write / changeCount race
+# --------------------------------------------------------------------------
+
+
+class TestInjectionIsAtomicAgainstPolling:
+    def test_poll_cannot_interleave_with_an_in_flight_injection(
+        self, make_monitor, pasteboard, tmp_path
+    ):
+        """The monitor thread must not observe a half-finished injection.
+
+        ``clearContents()`` bumps ``changeCount`` immediately, but
+        ``_last_change_count`` is only updated once the write completes. A poll
+        landing in that window used to see the injected content as a fresh user
+        copy; it now blocks on the injection lock instead.
+        """
+        monitor = make_monitor(sync_files=False, sync_images=True)
+
+        received = tmp_path / "from_peer.png"
+        received.write_bytes(IMAGE_A)
+
+        write_in_flight = threading.Event()
+        release_write = threading.Event()
+        poll_finished = threading.Event()
+
+        def pause_on_final_write(name):
+            # setPropertyList_forType_ is the last write of an image injection:
+            # by now the pasteboard holds the new content and a bumped
+            # changeCount, but _last_change_count is still stale.
+            if name == "setPropertyList_forType_":
+                write_in_flight.set()
+                release_write.wait(5)
+
+        pasteboard.on_write = pause_on_final_write
+
+        writer = threading.Thread(target=monitor.set_clipboard_files, args=([received],))
+        writer.start()
+        assert write_in_flight.wait(5), "injection never started"
+
+        def poll():
+            monitor._check_clipboard()
+            poll_finished.set()
+
+        poller = threading.Thread(target=poll)
+        poller.start()
+        try:
+            assert not poll_finished.wait(0.5), "poll ran while the injection was mid-write"
+        finally:
+            release_write.set()
+            writer.join(5)
+            poller.join(5)
+
+        assert poll_finished.is_set()
+        assert make_monitor.files_copied == []
+        assert monitor._last_change_count == pasteboard.changeCount()
+
+    def test_setters_leave_change_count_bookkeeping_consistent(
+        self, make_monitor, pasteboard, tmp_path
+    ):
+        monitor = make_monitor()
+
+        target = tmp_path / "doc.txt"
+        target.write_text("x")
+
+        monitor.set_clipboard_files([target])
+        assert monitor._last_change_count == pasteboard.changeCount()
+
+        monitor.set_clipboard_text("hello")
+        assert monitor._last_change_count == pasteboard.changeCount()
+
+        image = tmp_path / "img.png"
+        image.write_bytes(IMAGE_A)
+        monitor.set_clipboard_files([image])
+        assert monitor._last_change_count == pasteboard.changeCount()
+
+        # And a poll right afterwards is a no-op.
+        monitor._check_clipboard()
+        assert make_monitor.files_copied == []
+        assert make_monitor.text_copied == []
+
+
+# --------------------------------------------------------------------------
+# Feature toggles
+# --------------------------------------------------------------------------
+
+
+class TestFeatureToggles:
+    def test_images_ignored_when_disabled(self, make_monitor, pasteboard):
+        monitor = make_monitor(sync_images=False)
+
+        pasteboard.user_copies(**{NSPasteboardTypePNG: IMAGE_A})
+        monitor._check_clipboard()
+
+        assert make_monitor.files_copied == []
+
+    def test_files_ignored_when_disabled(self, make_monitor, pasteboard, tmp_path):
+        monitor = make_monitor(sync_files=False)
+
+        target = tmp_path / "doc.txt"
+        target.write_text("x")
+        pasteboard.user_copies(**{NSFilenamesPboardType: [str(target)]})
+        monitor._check_clipboard()
+
+        assert make_monitor.files_copied == []
+
+    def test_text_ignored_when_disabled(self, make_monitor, pasteboard):
+        monitor = make_monitor(sync_text=False)
+
+        pasteboard.user_copies(**{NSPasteboardTypeString: "hi"})
+        monitor._check_clipboard()
+
+        assert make_monitor.text_copied == []


### PR DESCRIPTION
Fixes the macOS half of #16. (Not `Closes` — the Windows half is a separate PR, and #16 should only close when both land.)

## The bug

`MacClipboardMonitor` used one field, `_last_content_hash`, to hold **either** a file-list hash **or** an image-data hash:

| site | what it wrote |
|---|---|
| `_handle_files()` | `_hash_file_list(...)` |
| `_handle_image()` | md5 of the image bytes |
| `set_clipboard_files()` | `_hash_file_list(...)` |

The two values come from different domains, so a comparison across kinds never matches.

When a received image was injected, `set_clipboard_files()` stored the **file-list** hash. With `sync_files=false` and `sync_images=true` the next poll skipped the file branch, took the image branch, hashed the image **data**, found no match against the stored file-list hash, and sent the image straight back to the peer — an echo loop.

## The fix

Split into `_last_file_hash` and `_last_image_hash` so a file-list hash can never be compared against an image hash. Every read and write of the old field was audited:

- `_handle_files()` / `set_clipboard_files()` / `_set_clipboard_files_only()` → `_last_file_hash`
- `_handle_image()` → `_last_image_hash`
- `_set_clipboard_image_file()` → **both**. This is the actual repair: an image injection puts a filename *and* PNG data on the pasteboard, so the next poll may take either branch depending on the toggles. Arming only one guard is what let the image escape. The image guard is armed from the *converted* PNG bytes, not the file on disk, so the JPEG/TIFF conversion path is covered too.

`_set_clipboard_files_only()` now arms the file guard itself rather than relying on its caller, so it is safe to call directly.

## The two robustness points — both fixed

**1. Prefix-only image hash — fixed.** `_handle_image()` hashed `data_bytes[:4096]` for anything larger than 4 KB, so two different images sharing a 4 KB prefix (same header, same first rows of pixels — very reachable for screenshots of the same window) were treated as identical and the second was never sent. Now hashes the full payload via a new `_hash_image_data()` helper. This is not on a hot path: `_check_clipboard()` returns early when `changeCount` is unchanged, so the hash runs once per clipboard change, not once per 0.3 s poll. Regression test included.

**2. The changeCount race — fixed.** `_last_change_count = self._pasteboard.changeCount()` was read *after* the pasteboard write, leaving a window in which the poller could see the new count and process the injection as a fresh user copy.

Closed with a re-entrant `_pasteboard_lock` held across *write-then-record* in the setters and across *read-then-record* in `_check_clipboard()`. The poller now either runs entirely before the write (sees the old count) or entirely after it (sees a count already matching `_last_change_count`).

I judged this safe because of how narrowly it is scoped:

- The handlers and their callbacks (`on_files_copied` → network send) run **outside** the lock, so a slow send can never stall an incoming paste.
- **No lock is ever held while acquiring another** anywhere in the class, so no ordering deadlock is possible. `_lock`, `_pasteboard_lock`, `_received_files_lock` and `_received_text_lock` are only ever taken sequentially.
- It is an `RLock` because `set_clipboard_files()` → `_set_clipboard_image_file()` → `_set_clipboard_files_only()` nests on the error path.

The hash guards remain the second line of defence for the window where a handler re-reads the pasteboard outside the lock, which is why both layers are tested independently.

## Deliberately not changed

- **`set_virtual_clipboard_files()` still assigns `self._last_content_hash`.** That method is owned by another work unit that is deleting it, so I left it byte-for-byte untouched; the assignment now lands on an attribute nothing reads. If that deletion does not land, the practical impact is still nil: the same method also registers the staging paths in `_received_files`, and `_handle_files()` checks that set independently, so the loop guard there survives. Worth re-checking if the deleting PR is dropped.
- **Cross-kind hash clearing.** Because the hashes are now independent, copying image A → copying files → copying image A again is suppressed, where previously the file copy would clobber the shared field and re-enable it. This is strictly *more* conservative (never more echo-prone), and it matches how `_last_text_hash` has always behaved. Left alone rather than adding cross-kind invalidation, which would reopen the hole this PR closes.
- **Colliding image spool filenames.** `_handle_image()` names its temp file from a second-resolution timestamp, so two images copied in the same second overwrite each other — which matters for the lazy >10 MB path that reads the file back on demand. Found while writing these tests; out of scope here, filed separately.

## Tests

New `tests/unit/test_macos_clipboard.py` — 20 tests, module previously had **zero** coverage, which is why this survived. Coverage of `macos/clipboard.py` goes **13% → 63%**.

`NSPasteboard` is patched out for an in-memory `FakePasteboard` before the monitor is constructed, so `generalPasteboard()` is never called and **the real system pasteboard is never touched**.

Coverage includes both directions, since a fix that just suppresses everything is not a fix:

- the exact regression — inject an image via `set_clipboard_files()`, present the image data with `sync_files=false` / `sync_images=true`, assert `on_files_copied` does **not** fire
- the same for the JPEG→PNG conversion path, plain files, and text
- a genuinely new image, a TIFF-only image, new files and new text all **do** fire
- a new image still fires immediately after an injection
- the two hashes do not clobber each other
- images sharing a 4 KB prefix are treated as different
- a concurrent poll blocks rather than observing a half-finished injection

**6 of these fail on the pre-fix code** (verified by stashing the source change), so they pin the actual defects rather than just documenting current behaviour.

Full suite: **107 passed** (87 before + 20 new).
