### PR TITLE
Single source of truth for the project version (1.0.3)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,9 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yank-clipboard-sync"
-version = "1.0.3"
+# Single source of truth: src/yank/__init__.py (__version__).
+# Resolved by setuptools at build time via [tool.setuptools.dynamic] below.
+dynamic = ["version"]
 description = "Cross-platform LAN clipboard synchronization for Windows, macOS, and Linux"
 readme = "README.md"
 requires-python = ">=3.8"
@@ -80,6 +82,9 @@ Issues = "https://github.com/yourusername/yank/issues"
 
 [tool.setuptools]
 package-dir = {"" = "src"}
+
+[tool.setuptools.dynamic]
+version = {attr = "yank.__version__"}
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/yank/__init__.py
+++ b/src/yank/__init__.py
@@ -4,7 +4,23 @@ Yank - LAN Clipboard Sync
 Cross-platform clipboard synchronization for Windows, macOS, and Linux
 """
 
-__version__ = "1.0.1"
+# ---------------------------------------------------------------------------
+# SINGLE SOURCE OF TRUTH FOR THE PROJECT VERSION.
+#
+# pyproject.toml declares ``dynamic = ["version"]`` and reads this attribute at
+# build time (``[tool.setuptools.dynamic] version = {attr = "yank.__version__"}``),
+# so the sdist/wheel metadata, ``pip show``, and ``yank --version`` can never
+# disagree.  Bump it here and nowhere else; release tags (``vX.Y.Z``) should
+# match, since the release workflow derives package versions from the tag name.
+#
+# Deliberately a plain literal rather than an ``importlib.metadata`` lookup:
+# Yank ships as a PyInstaller binary that carries no distribution metadata, so a
+# metadata lookup would fall back on every released build (and the import name
+# ``yank`` differs from the distribution name ``yank-clipboard-sync``, which
+# makes such lookups easy to get silently wrong).
+# ---------------------------------------------------------------------------
+__version__ = "1.0.3"
+
 __author__ = "Nasir Idrishi"
 __license__ = "MIT"
 

--- a/tests/unit/test_version.py
+++ b/tests/unit/test_version.py
@@ -1,0 +1,268 @@
+"""
+Tests for the single source of truth for the project version.
+
+``src/yank/__init__.py`` owns the version number.  ``pyproject.toml`` declares
+``dynamic = ["version"]`` and points setuptools at that attribute, so the
+distribution metadata, ``pip show``, and ``yank --version`` are all derived from
+one literal and cannot drift apart (see issue #18).
+
+Covers:
+- ``yank.__version__`` is importable, non-empty and release-shaped
+- ``pyproject.toml`` really is wired to the attribute and declares no static
+  version of its own
+- the build backend resolves that wiring to the same value
+- installed distribution metadata agrees with the attribute
+- the version still resolves when no distribution metadata exists at all
+  (the frozen PyInstaller case)
+- no other module in the package re-declares a version
+"""
+
+import importlib
+import importlib.metadata
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+import yank
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+SRC_DIR = REPO_ROOT / "src" / "yank"
+
+# The attribute pyproject is expected to read the version from.
+VERSION_ATTR = "yank.__version__"
+
+
+def _load_pyproject():
+    """Parse pyproject.toml into a dict, or return None if no TOML parser.
+
+    tomllib is stdlib on 3.11+; tomli is the 3.8-3.10 backport.  Neither is a
+    declared dev dependency, so callers must handle None by scanning lines --
+    the project floor is Python 3.8.
+    """
+    try:
+        import tomllib  # type: ignore[import-not-found]
+    except ModuleNotFoundError:  # pragma: no cover - Python < 3.11
+        try:
+            import tomli as tomllib  # type: ignore[no-redef]
+        except ModuleNotFoundError:
+            return None
+    with PYPROJECT.open("rb") as fh:
+        return tomllib.load(fh)
+
+
+def _section_lines(table):
+    """Yield the raw lines belonging to one top-level TOML table.
+
+    A deliberately small stand-in for a TOML parser, used only on interpreters
+    where neither tomllib nor tomli is importable.
+    """
+    current = None
+    for raw in PYPROJECT.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if line.startswith("[") and line.endswith("]"):
+            current = line[1:-1].strip()
+            continue
+        if current == table and line and not line.startswith("#"):
+            yield line
+
+
+def _project_name():
+    """The distribution name from pyproject -- not the same as the import name."""
+    data = _load_pyproject()
+    if data is not None:
+        return data["project"]["name"]
+    for line in _section_lines("project"):  # pragma: no cover - no TOML parser
+        match = re.match(r"""name\s*=\s*["'](.+?)["']""", line)
+        if match:
+            return match.group(1)
+    raise AssertionError("pyproject [project] declares no name")  # pragma: no cover
+
+
+DIST_NAME = _project_name()
+
+
+class TestVersionAttribute:
+    """The attribute itself must be usable by anything that imports yank."""
+
+    def test_version_is_importable_and_non_empty(self):
+        assert isinstance(yank.__version__, str)
+        assert yank.__version__.strip()
+
+    def test_version_is_release_shaped(self):
+        # e.g. 1.0.3, 1.2, 2.0.0rc1 -- rejects placeholders like "unknown"/"0".
+        assert re.match(
+            r"^\d+\.\d+(\.\d+)?([._-]?[a-zA-Z0-9]+)*$", yank.__version__
+        ), f"__version__ = {yank.__version__!r} does not look like a release version"
+
+    def test_version_is_exported(self):
+        assert "__version__" in yank.__all__
+
+
+class TestPyprojectWiring:
+    """pyproject.toml must derive its version from yank.__version__."""
+
+    def test_version_is_declared_dynamic(self):
+        data = _load_pyproject()
+        if data is None:  # pragma: no cover - only without tomllib/tomli
+            match = re.search(r"dynamic\s*=\s*\[([^\]]*)\]", " ".join(_section_lines("project")))
+            assert match, "pyproject [project] declares no dynamic fields"
+            assert "version" in match.group(1)
+            return
+        assert "version" in data["project"].get(
+            "dynamic", []
+        ), 'pyproject [project] must declare dynamic = ["version"]'
+
+    def test_no_static_version_in_pyproject(self):
+        """A static [project] version would immediately re-open issue #18."""
+        data = _load_pyproject()
+        if data is None:  # pragma: no cover - only without tomllib/tomli
+            assert not [ln for ln in _section_lines("project") if re.match(r"version\s*=", ln)]
+            return
+        assert "version" not in data["project"], (
+            "pyproject [project] declares a hardcoded version; it must stay dynamic "
+            "so src/yank/__init__.py remains the single source of truth"
+        )
+
+    def test_dynamic_version_points_at_the_package_attribute(self):
+        data = _load_pyproject()
+        if data is None:  # pragma: no cover - only without tomllib/tomli
+            assert VERSION_ATTR in " ".join(_section_lines("tool.setuptools.dynamic"))
+            return
+        assert data["tool"]["setuptools"]["dynamic"]["version"] == {"attr": VERSION_ATTR}
+
+
+class TestBuildBackend:
+    """The wiring is only real if the build backend resolves it."""
+
+    def test_built_metadata_version_matches_attribute(self, tmp_path, monkeypatch):
+        """Build the wheel metadata and check the version setuptools computed.
+
+        This is what ends up in the sdist/wheel, `pip show`, the GitHub release
+        artifacts, and any downstream packaging -- so it must equal the literal
+        in src/yank/__init__.py.
+        """
+        build_meta = pytest.importorskip("setuptools.build_meta")
+
+        monkeypatch.chdir(REPO_ROOT)
+        out_dir = tmp_path / "metadata"
+        out_dir.mkdir()
+        dist_info = build_meta.prepare_metadata_for_build_wheel(str(out_dir))
+
+        metadata = (out_dir / dist_info / "METADATA").read_text(encoding="utf-8")
+        built_version = re.search(r"^Version:\s*(.+)$", metadata, re.M)
+        built_name = re.search(r"^Name:\s*(.+)$", metadata, re.M)
+
+        assert built_version, metadata
+        assert built_version.group(1).strip() == yank.__version__, (
+            f"setuptools built version {built_version.group(1)!r} but "
+            f"yank.__version__ is {yank.__version__!r}"
+        )
+        assert built_name and built_name.group(1).strip() == DIST_NAME
+
+
+class TestInstalledMetadata:
+    """When the package is pip-installed, its metadata must match the attribute."""
+
+    def test_distribution_metadata_matches_attribute(self):
+        try:
+            declared = importlib.metadata.version(DIST_NAME)
+        except importlib.metadata.PackageNotFoundError:
+            pytest.skip(f"{DIST_NAME} is not installed in this environment")
+        assert declared == yank.__version__, (
+            f"installed metadata says {declared!r} but yank.__version__ is "
+            f"{yank.__version__!r}; reinstall the package after bumping the version"
+        )
+
+    def test_metadata_lookup_needs_the_distribution_name(self):
+        """Guards the footgun that makes metadata lookups silently fall back.
+
+        ``importlib.metadata.version("yank")`` never resolves for this project:
+        the import name is ``yank`` but the distribution is ``DIST_NAME``.
+        """
+        if DIST_NAME.replace("-", "_").lower() == "yank":
+            pytest.skip("distribution name now matches the import name")
+        with pytest.raises(importlib.metadata.PackageNotFoundError):
+            importlib.metadata.version("yank")
+
+
+class TestFrozenBuild:
+    """PyInstaller binaries carry no distribution metadata at all."""
+
+    def test_version_resolves_without_distribution_metadata(self, monkeypatch):
+        expected = yank.__version__
+
+        def _no_metadata(*args, **kwargs):
+            raise importlib.metadata.PackageNotFoundError("frozen build: no metadata")
+
+        monkeypatch.setattr(importlib.metadata, "version", _no_metadata)
+        monkeypatch.setattr(sys, "frozen", True, raising=False)
+        monkeypatch.setattr(sys, "_MEIPASS", "/tmp/_MEItest", raising=False)
+
+        try:
+            reloaded = importlib.reload(yank)
+            assert reloaded.__version__ == expected
+            assert reloaded.__version__.strip()
+        finally:
+            monkeypatch.undo()
+            importlib.reload(yank)
+
+    def test_importing_yank_never_needs_metadata(self, monkeypatch):
+        """Importing the package must not raise just because metadata is gone."""
+
+        def _explode(*args, **kwargs):
+            raise AssertionError("yank/__init__.py must not query package metadata")
+
+        monkeypatch.setattr(importlib.metadata, "version", _explode)
+        monkeypatch.setattr(importlib.metadata, "distribution", _explode)
+        try:
+            importlib.reload(yank)
+        finally:
+            monkeypatch.undo()
+            importlib.reload(yank)
+
+
+class TestNoDuplicateVersions:
+    """Nothing else in the package may declare a version of its own."""
+
+    def test_only_init_declares_a_version(self):
+        offenders = [
+            str(path.relative_to(REPO_ROOT))
+            for path in SRC_DIR.rglob("*.py")
+            if path.name != "__init__.py"
+            and re.search(r"^__version__\s*=", path.read_text(encoding="utf-8"), re.M)
+        ]
+        assert not offenders, f"version declared outside src/yank/__init__.py: {offenders}"
+
+    def test_no_module_hardcodes_the_current_version(self):
+        literal = re.compile(r"""["']""" + re.escape(yank.__version__) + r"""["']""")
+        offenders = [
+            str(path.relative_to(REPO_ROOT))
+            for path in SRC_DIR.rglob("*.py")
+            if path != SRC_DIR / "__init__.py" and literal.search(path.read_text(encoding="utf-8"))
+        ]
+        assert not offenders, f"version string hardcoded outside __init__.py: {offenders}"
+
+
+class TestCommandLine:
+    """`yank --version` is what users and release automation actually see."""
+
+    def test_cli_reports_the_package_version(self):
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "import sys; sys.argv = ['yank', '--version']; "
+                "from yank.main import main; main()",
+            ],
+            cwd=str(REPO_ROOT),
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        output = result.stdout + result.stderr
+        assert result.returncode == 0, output
+        assert yank.__version__ in output, output


### PR DESCRIPTION
Closes #18

## Problem

`pyproject.toml` declared `1.0.3` while `src/yank/__init__.py` declared `1.0.1`. `yank --version` reports the `__init__.py` value (`main.py:809`), so released binaries reported a version matching neither the package metadata nor the Homebrew/winget artifacts. Bumping both by hand just re-arms the same trap next release.

## Fix

`src/yank/__init__.py` is now the single source of truth. `pyproject.toml` declares `dynamic = ["version"]` and reads the attribute at build time:

```toml
[project]
name = "yank-clipboard-sync"
dynamic = ["version"]

[tool.setuptools.dynamic]
version = {attr = "yank.__version__"}
```

Resolved to **1.0.3** (the higher value, and what pyproject already claimed). There is now exactly one version literal in the repo.

## Why the attr direction rather than `importlib.metadata`

The metadata approach was the first choice, but it is genuinely wrong for this project:

1. **The shipped artifact has no metadata.** Yank releases are PyInstaller binaries; `yank.spec` does not `copy_metadata(...)`, so a frozen build has no `.dist-info` at all. A metadata lookup would hit its hardcoded fallback on *every released build* — meaning the number users actually see would come from a second hardcoded constant. That is the same drift problem wearing a different hat.
2. **The import name is not the distribution name.** The package imports as `yank` but the distribution is `yank-clipboard-sync`. `importlib.metadata.version("yank")` raises `PackageNotFoundError` even in a normal editable install (verified), so the fallback would silently mask *every* lookup and nobody would notice it never worked.

The `attr` direction has neither failure mode: the same literal is used in a source checkout, a pip install, and a frozen binary, and `pyproject` derives from it at build time.

## Verification

- Editable reinstall → `pip` metadata reports `1.0.3`; `yank --version` prints `Yank 1.0.3`. They agree, from one literal.
- Built the wheel metadata from a copy with `__version__` set to `9.9.9` → setuptools produced `Version: 9.9.9`, confirming the value is genuinely dynamic and not a stale static leftover.
- Negative test: temporarily restoring the exact bug state (static `version = "1.0.1"` in pyproject) fails 3 of the new tests, including the build round-trip.
- Full suite green: **101 passed** (87 before this change, 14 new).

## Tests

New `tests/unit/test_version.py`:

- `__version__` is importable, non-empty, release-shaped, and exported
- pyproject declares `version` dynamic, declares **no** static `[project] version`, and points at `yank.__version__` (parsed with `tomllib`, falling back to `tomli`, falling back to line scanning — `tomli` is not a dev dependency, so on the Python 3.8 floor the line-scanning path is the real one; it is exercised and passes)
- **build-backend round-trip**: runs `setuptools.build_meta.prepare_metadata_for_build_wheel` and asserts the `Version:` setuptools computed equals `yank.__version__` — this is what lands in the wheel and the release artifacts
- installed distribution metadata matches the attribute (skips when not installed)
- frozen-build path: with `importlib.metadata.version` patched to raise `PackageNotFoundError` and `sys.frozen` / `sys._MEIPASS` set, importing `yank` still yields the right version and never raises
- no module outside `__init__.py` declares `__version__` or hardcodes the version literal
- `yank --version` reports `yank.__version__`

## Other hardcoded versions found (reported, not changed)

Grepped `yank.spec`, `build.sh`, `build.ps1`, `.github/workflows/`, and `winget/`:

| Location | Finding |
|---|---|
| `yank.spec`, `build.sh`, `build.ps1` | No version references at all. Unaffected. |
| `.github/workflows/release.yml` | Derives every version from the **git tag** (`${TAG_NAME#v}`) — Homebrew formula, winget submission, and the `.deb` control file. It never reads `pyproject.toml` or `__init__.py`, so a tag can still disagree with the source. Out of scope here; the natural follow-up is a release-workflow guard asserting `yank.__version__` equals the tag. |
| `winget/*.yaml` (3 files) | Hardcode `PackageVersion: 1.0.1` and a `v1.0.1` installer URL — stale. In practice `release.yml` rewrites `PackageVersion`/`InstallerUrl`/`InstallerSha256` before submitting, and only in the fallback branch, so these checked-in values are cosmetic. Left untouched to keep this PR to one concern. |

Unrelated pre-existing gap noticed while testing: **`python -m yank` does not work** — there is no `src/yank/__main__.py`, so it fails with *"No module named yank.__main__"*, even though `CLAUDE.md` documents `python -m yank status`. The `yank` console script works fine. Not touched here.

`ruff` passes on both changed files and the new test; `black` leaves them unchanged. (Both tools report large pre-existing failures elsewhere in the repo, untouched by this PR.)
