### PR TITLE
Windows service manager: graceful stop, working reinstall check, utf-8 service log

### DIFF
--- a/src/yank/platform/windows/service.py
+++ b/src/yank/platform/windows/service.py
@@ -5,21 +5,48 @@ Manages Yank using Task Scheduler for auto-start on login and a detached
 process for the running service. Replaces the old pywin32 Windows Service
 approach which ran in Session 0 and could not access the user's clipboard.
 """
-import os
-import sys
-import subprocess
+import codecs
 import logging
+import os
+import re
+import subprocess
+import xml.etree.ElementTree as ET
 from pathlib import Path
-from typing import Tuple, Optional, List
+from typing import Any, List, Optional, Tuple
 
-from yank.common.service_manager import ServiceManager, ServiceInfo, ServiceStatus
+from yank.common.service_manager import ServiceInfo, ServiceManager, ServiceStatus
 
 logger = logging.getLogger(__name__)
+
+# ElementTree refuses str input that still carries an encoding declaration
+# ("Unicode strings with encoding declaration are not supported"), and schtasks
+# emits `<?xml version="1.0" encoding="UTF-16"?>`, so strip it after decoding.
+_XML_DECLARATION_RE = re.compile(r"^\s*<\?xml.*?\?>", re.DOTALL)
+
+# Byte-order mark left behind by some decoders; harmless to strip.
+_BOM_CHAR = chr(0xFEFF)
 
 
 class WindowsServiceManager(ServiceManager):
 
     TASK_NAME = "YankClipboardSync"
+
+    # Process creation flags (winbase.h)
+    CREATE_NEW_PROCESS_GROUP = 0x00000200
+    DETACHED_PROCESS = 0x00000008
+    CREATE_NO_WINDOW = 0x08000000
+
+    # Process access rights / control events / wait results
+    PROCESS_TERMINATE = 0x0001
+    SYNCHRONIZE = 0x00100000
+    CTRL_BREAK_EVENT = 1
+    WAIT_OBJECT_0 = 0x00000000
+
+    # How long stop() waits for a clean shutdown before force-killing, and how
+    # long it waits for the kill itself to land (so a caller that restarts
+    # immediately does not race the singleton lock).
+    GRACEFUL_STOP_TIMEOUT_MS = 5000
+    FORCE_STOP_TIMEOUT_MS = 2000
 
     def __init__(self):
         local_app = Path(os.environ.get("LOCALAPPDATA", Path.home() / "AppData" / "Local"))
@@ -101,8 +128,13 @@ class WindowsServiceManager(ServiceManager):
         info = self.get_status()
         if info.status == ServiceStatus.RUNNING:
             if self._needs_reinstall():
-                self.stop()
-                self.install()
+                logger.info("Scheduled task points at a stale binary; reinstalling")
+                ok, msg = self.stop()
+                if not ok:
+                    return False, f"Could not stop the running agent to reinstall: {msg}"
+                ok, msg = self.install()
+                if not ok:
+                    return False, msg
             else:
                 return True, f"Already running (PID {info.pid})"
 
@@ -115,39 +147,82 @@ class WindowsServiceManager(ServiceManager):
             self._log_dir.mkdir(parents=True, exist_ok=True)
             args = self.get_service_args()
 
-            CREATE_NEW_PROCESS_GROUP = 0x00000200
-            DETACHED_PROCESS = 0x00000008
-            CREATE_NO_WINDOW = 0x08000000
+            # The child prints arbitrary clipboard text, so the log must not be
+            # bound to the locale codepage (cp1252). Two separate things decide
+            # that: this handle's encoding (what *we* would write) and the
+            # child's own sys.stdout encoding, which Python derives from the
+            # environment because the stream is a file, not a console — hence
+            # PYTHONIOENCODING below. A PyInstaller-frozen child may run with an
+            # isolated config that ignores PYTHON* vars; there the runtime hook
+            # (hooks/hook-yank-console.py) is the remaining line of defence.
+            env = dict(os.environ)
+            env.setdefault("PYTHONIOENCODING", "utf-8:replace")
 
-            log_handle = open(self._log_path, "a")
-            subprocess.Popen(
-                args,
-                creationflags=DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW,
-                stdout=log_handle,
-                stderr=log_handle,
-                stdin=subprocess.DEVNULL,
+            # CREATE_NEW_PROCESS_GROUP makes the child's PID double as its
+            # process-group id, which is what stop() addresses CTRL_BREAK to.
+            creationflags = (
+                self.DETACHED_PROCESS | self.CREATE_NEW_PROCESS_GROUP | self.CREATE_NO_WINDOW
             )
+
+            # CreateProcess duplicates the handle into the child, so closing our
+            # copy as soon as Popen returns is safe and keeps `yank start` from
+            # leaking a file handle for the rest of its (short) life.
+            with open(self._log_path, "a", encoding="utf-8", errors="replace") as log_handle:
+                subprocess.Popen(
+                    args,
+                    creationflags=creationflags,
+                    stdout=log_handle,
+                    stderr=log_handle,
+                    stdin=subprocess.DEVNULL,
+                    env=env,
+                )
             return True, "Started"
         except Exception as e:
             return False, str(e)
 
     def stop(self) -> Tuple[bool, str]:
+        """Stop the agent, preferring a clean shutdown over a hard kill.
+
+        A hard TerminateProcess leaves sockets and worker threads unclosed and
+        skips release_singleton(), stranding the lock/PID pair in %TEMP% until
+        stale-PID detection notices. main._run_foreground() installs signal
+        handlers that stop the agent and release the lock, so we first try to
+        deliver a console control event to the child's process group.
+
+        That attempt is best-effort: GenerateConsoleCtrlEvent only reaches
+        processes attached to *our* console, and start() launches the agent with
+        DETACHED_PROCESS — it has no console at all. Task Scheduler's ONLOGON
+        copy is equally detached. Delivery therefore fails on the common path,
+        and the child would have to handle SIGBREAK (which is what CPython maps
+        CTRL_BREAK onto) for it to shut down cleanly even when it lands. The
+        TerminateProcess fallback below is not a corner case; it is the norm.
+        """
         from yank.common.singleton import get_existing_instance_pid
         pid = get_existing_instance_pid()
         if not pid:
             return True, "Not running"
 
+        if pid < 0:
+            # Port is in use but the owning PID is unknown — nothing to signal.
+            return False, "Running but PID unknown; stop manually or kill the process on port 9876"
+
         try:
-            import ctypes
-            PROCESS_TERMINATE = 0x0001
-            kernel32 = ctypes.windll.kernel32
-            handle = kernel32.OpenProcess(PROCESS_TERMINATE, False, pid)
-            if handle:
-                kernel32.TerminateProcess(handle, 0)
-                kernel32.CloseHandle(handle)
-                return True, f"Stopped (PID {pid})"
-            else:
+            kernel32 = self._get_kernel32()
+            handle = kernel32.OpenProcess(self.PROCESS_TERMINATE | self.SYNCHRONIZE, False, pid)
+            if not handle:
                 return False, f"Could not open process {pid}"
+
+            try:
+                if self._send_ctrl_break(kernel32, pid):
+                    if self._wait_for_exit(kernel32, handle, self.GRACEFUL_STOP_TIMEOUT_MS):
+                        return True, f"Stopped gracefully (PID {pid})"
+                    logger.debug("PID %s did not exit after CTRL_BREAK; terminating", pid)
+
+                kernel32.TerminateProcess(handle, 0)
+                self._wait_for_exit(kernel32, handle, self.FORCE_STOP_TIMEOUT_MS)
+                return True, f"Stopped (PID {pid})"
+            finally:
+                kernel32.CloseHandle(handle)
         except Exception as e:
             return False, str(e)
 
@@ -179,7 +254,171 @@ class WindowsServiceManager(ServiceManager):
             return False
 
     def _needs_reinstall(self) -> bool:
-        # Could parse schtasks /Query /XML, but for simplicity
-        # we just reinstall on start if the binary path changed.
-        # The install() with /F flag overwrites existing task.
-        return False
+        """True when the installed task launches something other than we would.
+
+        The macOS manager does the same by comparing plist ProgramArguments;
+        here the equivalent source of truth is the task's Exec action.
+
+        Unlike the macOS version this returns *False* when the task cannot be
+        read or parsed. start() reacts to True by stopping and reinstalling, so
+        treating an unreadable query as "stale" would turn every start into a
+        stop/reinstall cycle.
+        """
+        installed = self._query_task_exec()
+        if installed is None:
+            return False
+
+        command, arguments = installed
+        installed_line = self._canonical_command_line(command, arguments)
+        expected_line = self._canonical_command_line(*self._expected_exec())
+        if installed_line == expected_line:
+            return False
+
+        logger.info(
+            "Scheduled task runs %r but should run %r; reinstalling",
+            installed_line, expected_line,
+        )
+        return True
+
+    def _expected_exec(self) -> Tuple[str, str]:
+        """The (command, arguments) install() would register right now."""
+        args = self.get_service_args()
+        return args[0], " ".join(args[1:])
+
+    def _query_task_exec(self) -> Optional[Tuple[str, str]]:
+        """Return (command, arguments) from the installed task, or None."""
+        try:
+            result = subprocess.run(
+                ["schtasks", "/Query", "/TN", self.TASK_NAME, "/XML"],
+                capture_output=True, timeout=10,
+            )
+        except Exception as e:
+            logger.debug("schtasks query failed: %s", e)
+            return None
+
+        if result.returncode != 0:
+            return None
+
+        text = self._decode_schtasks_xml(result.stdout)
+        if not text:
+            return None
+
+        try:
+            root = ET.fromstring(text)
+        except Exception as e:
+            # ParseError for malformed XML, ValueError if an encoding
+            # declaration survived the strip above. Either way we do not know
+            # what is installed, so _needs_reinstall() must not guess.
+            logger.debug("Could not parse schtasks XML: %s", e)
+            return None
+
+        # Task Scheduler XML lives in the
+        # http://schemas.microsoft.com/windows/2004/02/mit/task namespace;
+        # `{*}` matches any (or no) namespace so we do not depend on the exact
+        # schema version schtasks emits.
+        exec_el = root.find(".//{*}Actions/{*}Exec")
+        if exec_el is None:
+            exec_el = root.find(".//{*}Exec")
+        if exec_el is None:
+            return None
+
+        command = exec_el.findtext("{*}Command")
+        if command is None:
+            return None
+
+        return command, exec_el.findtext("{*}Arguments") or ""
+
+    @staticmethod
+    def _decode_schtasks_xml(raw: Any) -> Optional[str]:
+        """Decode schtasks /XML output (UTF-16 with BOM in practice) to str."""
+        if not raw:
+            return None
+
+        if isinstance(raw, (bytes, bytearray)):
+            data = bytes(raw)
+            if data.startswith(codecs.BOM_UTF16_LE) or data.startswith(codecs.BOM_UTF16_BE):
+                text = data.decode("utf-16", errors="replace")
+            elif data.startswith(codecs.BOM_UTF8):
+                text = data.decode("utf-8-sig", errors="replace")
+            elif b"\x00" in data[:64]:
+                # UTF-16 without a BOM (seen when output is piped).
+                text = data.decode("utf-16-le", errors="replace")
+            else:
+                try:
+                    text = data.decode("utf-8")
+                except UnicodeDecodeError:
+                    text = data.decode("cp1252", errors="replace")
+        else:
+            text = str(raw)
+
+        text = _XML_DECLARATION_RE.sub("", text.lstrip(_BOM_CHAR), count=1).strip()
+        return text or None
+
+    @staticmethod
+    def _canonical_command_line(command: str, arguments: str = "") -> str:
+        """Flatten an Exec action into one comparable string.
+
+        Command and Arguments are joined rather than compared field by field:
+        we hand schtasks a single /TR string and it decides where to split it,
+        so a task whose whole command line landed in <Command> must still
+        compare equal — otherwise every start() would trigger a reinstall.
+
+        Quotes are dropped, whitespace collapsed, separators unified and case
+        folded, since Windows paths are case-insensitive and accept either
+        slash. Both sides go through this, so the folding cannot hide a real
+        difference in the binary path or the flags.
+        """
+        line = f"{command} {arguments}".replace('"', " ")
+        return " ".join(line.split()).replace("/", "\\").lower()
+
+    @staticmethod
+    def _get_kernel32() -> Any:
+        """Return a kernel32 binding with the prototypes stop() relies on.
+
+        Isolated in a method so the import stays lazy (this module must import
+        on non-Windows hosts, where ctypes.windll does not exist) and so tests
+        can substitute a mock.
+
+        A private WinDLL instance is used rather than the shared
+        ctypes.windll.kernel32 so declaring argtypes/restype here cannot change
+        how other modules (e.g. common/singleton.py) call the same functions.
+        HANDLEs must be pointer-sized: with the default int prototypes a handle
+        would round-trip through a 32-bit c_int.
+        """
+        import ctypes
+        kernel32 = ctypes.WinDLL("kernel32")  # type: ignore[attr-defined]
+
+        kernel32.OpenProcess.argtypes = [ctypes.c_uint32, ctypes.c_int, ctypes.c_uint32]
+        kernel32.OpenProcess.restype = ctypes.c_void_p
+        kernel32.GenerateConsoleCtrlEvent.argtypes = [ctypes.c_uint32, ctypes.c_uint32]
+        kernel32.GenerateConsoleCtrlEvent.restype = ctypes.c_int
+        kernel32.WaitForSingleObject.argtypes = [ctypes.c_void_p, ctypes.c_uint32]
+        kernel32.WaitForSingleObject.restype = ctypes.c_uint32
+        kernel32.TerminateProcess.argtypes = [ctypes.c_void_p, ctypes.c_uint32]
+        kernel32.TerminateProcess.restype = ctypes.c_int
+        kernel32.CloseHandle.argtypes = [ctypes.c_void_p]
+        kernel32.CloseHandle.restype = ctypes.c_int
+
+        return kernel32
+
+    def _send_ctrl_break(self, kernel32: Any, pid: int) -> bool:
+        """Send CTRL_BREAK_EVENT to the process group whose id is `pid`.
+
+        Returns False when the event could not be delivered, which is the usual
+        outcome for a detached child (see stop()).
+        """
+        try:
+            return bool(kernel32.GenerateConsoleCtrlEvent(self.CTRL_BREAK_EVENT, pid))
+        except Exception as e:
+            logger.debug("GenerateConsoleCtrlEvent failed for PID %s: %s", pid, e)
+            return False
+
+    def _wait_for_exit(self, kernel32: Any, handle: Any, timeout_ms: int) -> bool:
+        """Wait up to timeout_ms for the process to exit. True if it did."""
+        try:
+            return bool(
+                kernel32.WaitForSingleObject(handle, timeout_ms) == self.WAIT_OBJECT_0
+            )
+        except Exception as e:
+            logger.debug("WaitForSingleObject failed: %s", e)
+            return False

--- a/tests/unit/test_windows_service.py
+++ b/tests/unit/test_windows_service.py
@@ -1,0 +1,462 @@
+"""
+Tests for the Windows service manager (yank.platform.windows.service).
+
+These run on any host. The module under test touches Windows-only APIs
+(schtasks, kernel32, detached Popen) at call time, never at import time, so
+every one of them is mocked here:
+
+- subprocess.run       -> canned `schtasks /Query /XML` output
+- subprocess.Popen     -> never actually spawns the agent
+- _get_kernel32()      -> MagicMock (ctypes.windll does not exist off Windows)
+- builtins.open        -> the service log is never created
+
+Nothing in this file installs, starts, or stops a real service.
+"""
+from pathlib import Path
+from unittest.mock import MagicMock, mock_open, patch
+
+import pytest
+
+from yank.common.service_manager import ServiceInfo, ServiceStatus
+from yank.platform.windows.service import WindowsServiceManager
+
+EXE = r"C:\Program Files\Yank\yank.exe"
+SERVICE_ARGS = [EXE, "start", "--foreground"]
+
+TASK_XML = """<?xml version="1.0" encoding="UTF-16"?>
+<Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
+  <RegistrationInfo>
+    <Date>2026-01-01T12:00:00</Date>
+    <Author>DESKTOP-ABC\\user</Author>
+    <URI>\\YankClipboardSync</URI>
+  </RegistrationInfo>
+  <Triggers>
+    <LogonTrigger>
+      <Enabled>true</Enabled>
+      <UserId>DESKTOP-ABC\\user</UserId>
+    </LogonTrigger>
+  </Triggers>
+  <Principals>
+    <Principal id="Author">
+      <UserId>S-1-5-21-1111111111-2222222222-3333333333-1001</UserId>
+      <LogonType>InteractiveToken</LogonType>
+      <RunLevel>LeastPrivilege</RunLevel>
+    </Principal>
+  </Principals>
+  <Settings>
+    <MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>
+    <StartWhenAvailable>false</StartWhenAvailable>
+    <Enabled>true</Enabled>
+  </Settings>
+  <Actions Context="Author">
+    <Exec>
+      <Command>{command}</Command>{arguments}
+    </Exec>
+  </Actions>
+</Task>
+"""
+
+
+def task_xml(command=EXE, arguments="start --foreground", quoted=True, encoding="utf-16"):
+    """Build schtasks-style XML. Returns bytes (or str when encoding is None)."""
+    command_text = f'"{command}"' if quoted else command
+    args_text = f"\n      <Arguments>{arguments}</Arguments>" if arguments is not None else ""
+    xml = TASK_XML.format(command=command_text, arguments=args_text)
+    return xml if encoding is None else xml.encode(encoding)
+
+
+def completed(stdout, returncode=0):
+    result = MagicMock()
+    result.returncode = returncode
+    result.stdout = stdout
+    result.stderr = b""
+    return result
+
+
+def make_kernel32(open_handle=0x1234, ctrl_break=1, wait_results=(0,)):
+    kernel32 = MagicMock(name="kernel32")
+    kernel32.OpenProcess.return_value = open_handle
+    kernel32.GenerateConsoleCtrlEvent.return_value = ctrl_break
+    kernel32.WaitForSingleObject.side_effect = list(wait_results)
+    kernel32.TerminateProcess.return_value = 1
+    kernel32.CloseHandle.return_value = 1
+    return kernel32
+
+
+def call_names(mock_obj):
+    """Ordered list of child-method names called on a MagicMock."""
+    return [name for name, _, _ in mock_obj.mock_calls]
+
+
+@pytest.fixture
+def mgr():
+    manager = WindowsServiceManager()
+    with patch.object(WindowsServiceManager, "get_service_args", return_value=list(SERVICE_ARGS)):
+        yield manager
+
+
+# ── module import ────────────────────────────────────────────────────────
+
+
+class TestImportsOffWindows:
+    def test_module_imports_and_instantiates(self):
+        """No Windows-only import may run at import/construction time."""
+        manager = WindowsServiceManager()
+        assert manager.TASK_NAME == "YankClipboardSync"
+        assert manager.get_log_path().endswith("yank.log")
+
+
+# ── _needs_reinstall: schtasks /Query /XML parsing ───────────────────────
+
+
+class TestNeedsReinstall:
+    """#14: _needs_reinstall() was hardcoded False, so the reinstall branch in
+    start() was dead code and upgrades kept launching the old exe path."""
+
+    def test_queries_task_xml_as_bytes(self, mgr):
+        with patch("yank.platform.windows.service.subprocess.run") as run:
+            run.return_value = completed(task_xml())
+            mgr._needs_reinstall()
+
+        run.assert_called_once()
+        assert run.call_args[0][0] == [
+            "schtasks", "/Query", "/TN", "YankClipboardSync", "/XML",
+        ]
+        # text=True would mangle schtasks' UTF-16 output.
+        assert run.call_args[1].get("text") is not True
+
+    def test_matching_task_does_not_need_reinstall(self, mgr):
+        with patch("yank.platform.windows.service.subprocess.run") as run:
+            run.return_value = completed(task_xml())
+            assert mgr._needs_reinstall() is False
+
+    def test_stale_binary_path_needs_reinstall(self, mgr):
+        stale = task_xml(command=r"C:\Users\user\AppData\Local\Yank\old\yank.exe")
+        with patch("yank.platform.windows.service.subprocess.run") as run:
+            run.return_value = completed(stale)
+            assert mgr._needs_reinstall() is True
+
+    def test_stale_arguments_need_reinstall(self, mgr):
+        """A task installed in dev mode (python -m yank) vs. a frozen exe."""
+        stale = task_xml(command=r"C:\Python312\python.exe", arguments="-m yank start --foreground")
+        with patch("yank.platform.windows.service.subprocess.run") as run:
+            run.return_value = completed(stale)
+            assert mgr._needs_reinstall() is True
+
+    def test_same_binary_different_flags_needs_reinstall(self, mgr):
+        with patch("yank.platform.windows.service.subprocess.run") as run:
+            run.return_value = completed(task_xml(arguments="start"))
+            assert mgr._needs_reinstall() is True
+
+    def test_quoting_case_and_separators_are_normalized(self, mgr):
+        """Windows paths are case-insensitive and accept either separator, and
+        schtasks may or may not report the quotes we passed via /TR."""
+        equivalent = task_xml(
+            command="c:/PROGRAM FILES/Yank/YANK.EXE",
+            quoted=False,
+            arguments="start   --foreground",
+        )
+        with patch("yank.platform.windows.service.subprocess.run") as run:
+            run.return_value = completed(equivalent)
+            assert mgr._needs_reinstall() is False
+
+    def test_unsplit_command_line_is_not_treated_as_stale(self, mgr):
+        """schtasks decides where to split the /TR string. If it keeps the whole
+        line in <Command>, that must still compare equal — otherwise every
+        start() would stop and reinstall the service."""
+        unsplit = task_xml(
+            command=f'"{EXE}" start --foreground', quoted=False, arguments=None
+        )
+        with patch("yank.platform.windows.service.subprocess.run") as run:
+            run.return_value = completed(unsplit)
+            assert mgr._needs_reinstall() is False
+
+    def test_utf16_without_bom_is_decoded(self, mgr):
+        with patch("yank.platform.windows.service.subprocess.run") as run:
+            run.return_value = completed(task_xml(encoding="utf-16-le"))
+            assert mgr._needs_reinstall() is False
+
+    def test_utf8_output_is_decoded(self, mgr):
+        with patch("yank.platform.windows.service.subprocess.run") as run:
+            run.return_value = completed(task_xml(encoding="utf-8"))
+            assert mgr._needs_reinstall() is False
+
+    def test_str_output_with_encoding_declaration_is_handled(self, mgr):
+        """ElementTree rejects str input carrying an encoding declaration; the
+        declaration must be stripped rather than blowing up."""
+        with patch("yank.platform.windows.service.subprocess.run") as run:
+            run.return_value = completed(task_xml(encoding=None))
+            assert mgr._needs_reinstall() is False
+
+    # — unknown state must never mean "reinstall" —
+
+    def test_unparseable_output_returns_false(self, mgr):
+        with patch("yank.platform.windows.service.subprocess.run") as run:
+            run.return_value = completed(b"\x00\x01 not xml at all <<<")
+            assert mgr._needs_reinstall() is False
+
+    def test_truncated_xml_returns_false(self, mgr):
+        with patch("yank.platform.windows.service.subprocess.run") as run:
+            run.return_value = completed(b"<Task><Actions><Exec><Command>c:\\yank.exe")
+            assert mgr._needs_reinstall() is False
+
+    def test_empty_output_returns_false(self, mgr):
+        with patch("yank.platform.windows.service.subprocess.run") as run:
+            run.return_value = completed(b"")
+            assert mgr._needs_reinstall() is False
+
+    def test_query_failure_returns_false(self, mgr):
+        with patch("yank.platform.windows.service.subprocess.run") as run:
+            run.return_value = completed(b"ERROR: cannot find the file specified.", returncode=1)
+            assert mgr._needs_reinstall() is False
+
+    def test_schtasks_missing_returns_false(self, mgr):
+        with patch("yank.platform.windows.service.subprocess.run", side_effect=FileNotFoundError):
+            assert mgr._needs_reinstall() is False
+
+    def test_non_exec_action_returns_false(self, mgr):
+        """A task rewritten to a ComHandler action has no Command to compare."""
+        xml = (
+            '<Task xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">'
+            "<Actions><ComHandler><ClassId>{0}</ClassId></ComHandler></Actions></Task>"
+        ).encode("utf-16")
+        with patch("yank.platform.windows.service.subprocess.run") as run:
+            run.return_value = completed(xml)
+            assert mgr._needs_reinstall() is False
+
+    def test_missing_arguments_element_compares_as_empty(self, mgr):
+        with patch("yank.platform.windows.service.subprocess.run") as run:
+            run.return_value = completed(task_xml(arguments=None))
+            # Installed task takes no arguments, we expect "start --foreground".
+            assert mgr._needs_reinstall() is True
+
+    def test_namespaceless_xml_still_parses(self, mgr):
+        xml = (
+            "<Task><Actions><Exec>"
+            f"<Command>{EXE}</Command><Arguments>start --foreground</Arguments>"
+            "</Exec></Actions></Task>"
+        ).encode("utf-16")
+        with patch("yank.platform.windows.service.subprocess.run") as run:
+            run.return_value = completed(xml)
+            assert mgr._needs_reinstall() is False
+
+
+# ── stop(): graceful first, hard kill as fallback ────────────────────────
+
+
+class TestStop:
+    """#14: stop() used to go straight to TerminateProcess, so the agent never
+    closed its sockets/threads and never ran release_singleton()."""
+
+    def _stop_with(self, mgr, kernel32, pid=4321):
+        with patch("yank.common.singleton.get_existing_instance_pid", return_value=pid), \
+                patch.object(WindowsServiceManager, "_get_kernel32", return_value=kernel32):
+            return mgr.stop()
+
+    def test_not_running_is_a_noop(self, mgr):
+        kernel32 = make_kernel32()
+        ok, msg = self._stop_with(mgr, kernel32, pid=None)
+        assert (ok, msg) == (True, "Not running")
+        assert kernel32.mock_calls == []
+
+    def test_unknown_pid_does_not_signal_anything(self, mgr):
+        kernel32 = make_kernel32()
+        ok, msg = self._stop_with(mgr, kernel32, pid=-1)
+        assert ok is False
+        assert "PID unknown" in msg
+        assert kernel32.mock_calls == []
+
+    def test_graceful_ctrl_break_avoids_terminate(self, mgr):
+        kernel32 = make_kernel32(ctrl_break=1, wait_results=(0,))
+        ok, msg = self._stop_with(mgr, kernel32)
+
+        assert ok is True
+        assert msg == "Stopped gracefully (PID 4321)"
+        kernel32.TerminateProcess.assert_not_called()
+        assert call_names(kernel32) == [
+            "OpenProcess", "GenerateConsoleCtrlEvent", "WaitForSingleObject", "CloseHandle",
+        ]
+
+    def test_ctrl_break_targets_the_process_group(self, mgr):
+        kernel32 = make_kernel32()
+        self._stop_with(mgr, kernel32)
+        kernel32.GenerateConsoleCtrlEvent.assert_called_once_with(
+            WindowsServiceManager.CTRL_BREAK_EVENT, 4321
+        )
+
+    def test_falls_back_to_terminate_when_process_ignores_ctrl_break(self, mgr):
+        WAIT_TIMEOUT = 0x102
+        kernel32 = make_kernel32(ctrl_break=1, wait_results=(WAIT_TIMEOUT, 0))
+        ok, msg = self._stop_with(mgr, kernel32)
+
+        assert ok is True
+        assert msg == "Stopped (PID 4321)"
+        assert call_names(kernel32) == [
+            "OpenProcess",
+            "GenerateConsoleCtrlEvent",
+            "WaitForSingleObject",
+            "TerminateProcess",
+            "WaitForSingleObject",
+            "CloseHandle",
+        ]
+
+    def test_undeliverable_ctrl_break_terminates_without_waiting(self, mgr):
+        """The detached child has no console, so delivery usually fails —
+        do not burn the graceful timeout in that case."""
+        kernel32 = make_kernel32(ctrl_break=0, wait_results=(0,))
+        ok, msg = self._stop_with(mgr, kernel32)
+
+        assert (ok, msg) == (True, "Stopped (PID 4321)")
+        assert call_names(kernel32) == [
+            "OpenProcess", "GenerateConsoleCtrlEvent", "TerminateProcess",
+            "WaitForSingleObject", "CloseHandle",
+        ]
+
+    def test_ctrl_break_raising_falls_back_to_terminate(self, mgr):
+        kernel32 = make_kernel32(wait_results=(0,))
+        kernel32.GenerateConsoleCtrlEvent.side_effect = OSError("no console")
+        ok, _ = self._stop_with(mgr, kernel32)
+
+        assert ok is True
+        kernel32.TerminateProcess.assert_called_once()
+
+    def test_graceful_timeout_is_bounded(self, mgr):
+        kernel32 = make_kernel32(wait_results=(0,))
+        self._stop_with(mgr, kernel32)
+        handle, timeout = kernel32.WaitForSingleObject.call_args[0]
+        assert handle == 0x1234
+        assert timeout == WindowsServiceManager.GRACEFUL_STOP_TIMEOUT_MS
+
+    def test_open_process_failure_is_reported(self, mgr):
+        kernel32 = make_kernel32(open_handle=0)
+        ok, msg = self._stop_with(mgr, kernel32)
+
+        assert ok is False
+        assert msg == "Could not open process 4321"
+        kernel32.TerminateProcess.assert_not_called()
+        kernel32.CloseHandle.assert_not_called()
+
+    def test_handle_is_closed_even_when_terminate_raises(self, mgr):
+        kernel32 = make_kernel32(ctrl_break=0)
+        kernel32.TerminateProcess.side_effect = OSError("access denied")
+        ok, msg = self._stop_with(mgr, kernel32)
+
+        assert ok is False
+        assert "access denied" in msg
+        kernel32.CloseHandle.assert_called_once_with(0x1234)
+
+    def test_kernel32_unavailable_is_reported(self, mgr):
+        with patch("yank.common.singleton.get_existing_instance_pid", return_value=99), \
+                patch.object(
+                    WindowsServiceManager, "_get_kernel32", side_effect=AttributeError("windll")
+                ):
+            ok, msg = mgr.stop()
+        assert ok is False
+        assert "windll" in msg
+
+
+# ── start(): log encoding, handle lifetime, reinstall branch ─────────────
+
+
+class _StartHarness:
+    """Patches everything start() would otherwise do for real."""
+
+    def __init__(self, status=ServiceStatus.STOPPED, needs_reinstall=False):
+        self.status = status
+        self.needs_reinstall = needs_reinstall
+        self.open_mock = mock_open()
+
+    def __enter__(self):
+        info = ServiceInfo(status=self.status, pid=777, enabled=True)
+        self._patches = [
+            patch.object(WindowsServiceManager, "get_status", return_value=info),
+            patch.object(WindowsServiceManager, "_is_task_installed", return_value=True),
+            patch.object(
+                WindowsServiceManager, "_needs_reinstall", return_value=self.needs_reinstall
+            ),
+            patch.object(WindowsServiceManager, "stop", return_value=(True, "Stopped")),
+            patch.object(WindowsServiceManager, "install", return_value=(True, "Created")),
+            patch.object(Path, "mkdir"),
+            patch("yank.platform.windows.service.subprocess.Popen"),
+            patch("builtins.open", self.open_mock),
+        ]
+        started = [p.start() for p in self._patches]
+        self.get_status, self.is_installed, self.needs, self.stop, self.install = started[:5]
+        self.popen = started[6]
+        return self
+
+    def __exit__(self, *exc):
+        for p in reversed(self._patches):
+            p.stop()
+        return False
+
+
+class TestStartLogHandle:
+    """Part of #12: the detached child's stdout/stderr log was opened with the
+    locale codepage, so emoji/CJK clipboard text raised UnicodeEncodeError."""
+
+    def test_log_is_opened_as_utf8_with_replacement(self, mgr):
+        with _StartHarness() as h:
+            ok, msg = mgr.start()
+
+        assert (ok, msg) == (True, "Started")
+        args, kwargs = h.open_mock.call_args
+        assert args[1] == "a"
+        assert kwargs["encoding"] == "utf-8"
+        assert kwargs["errors"] == "replace"
+
+    def test_child_environment_forces_utf8_stdio(self, mgr):
+        """The parent's open() encoding does not reach the child; the child
+        picks its stdout encoding from the environment."""
+        with _StartHarness() as h:
+            mgr.start()
+
+        env = h.popen.call_args[1]["env"]
+        assert env["PYTHONIOENCODING"] == "utf-8:replace"
+        assert "PATH" in env or "Path" in env  # inherited, not replaced
+
+    def test_log_handle_is_closed_in_the_parent(self, mgr):
+        with _StartHarness() as h:
+            mgr.start()
+
+        handle = h.open_mock.return_value
+        assert h.popen.call_args[1]["stdout"] is handle
+        assert h.popen.call_args[1]["stderr"] is handle
+        handle.__exit__.assert_called()
+
+    def test_child_keeps_its_own_process_group(self, mgr):
+        """stop() delivers CTRL_BREAK to the group, so the flag must stay set."""
+        with _StartHarness() as h:
+            mgr.start()
+
+        flags = h.popen.call_args[1]["creationflags"]
+        assert flags & WindowsServiceManager.CREATE_NEW_PROCESS_GROUP
+        assert flags & WindowsServiceManager.DETACHED_PROCESS
+
+
+class TestStartReinstallBranch:
+    def test_running_with_current_binary_is_left_alone(self, mgr):
+        with _StartHarness(status=ServiceStatus.RUNNING, needs_reinstall=False) as h:
+            ok, msg = mgr.start()
+
+        assert (ok, msg) == (True, "Already running (PID 777)")
+        h.popen.assert_not_called()
+        h.install.assert_not_called()
+
+    def test_running_with_stale_binary_is_restarted(self, mgr):
+        with _StartHarness(status=ServiceStatus.RUNNING, needs_reinstall=True) as h:
+            ok, msg = mgr.start()
+
+        assert (ok, msg) == (True, "Started")
+        h.stop.assert_called_once()
+        h.install.assert_called_once()
+        h.popen.assert_called_once()
+
+    def test_reinstall_aborts_when_the_old_process_cannot_be_stopped(self, mgr):
+        with _StartHarness(status=ServiceStatus.RUNNING, needs_reinstall=True) as h:
+            h.stop.return_value = (False, "Could not open process 777")
+            ok, msg = mgr.start()
+
+        assert ok is False
+        assert "Could not open process 777" in msg
+        h.popen.assert_not_called()


### PR DESCRIPTION
Closes #14, and the service-log half of #12.

Three fixes in `src/yank/platform/windows/service.py`, plus the first tests that file has ever had.

### 1. `stop()` no longer hard-kills the agent (#14)

It went straight to `OpenProcess` + `TerminateProcess`, so sockets and worker threads were never closed and `release_singleton()` never ran — the lock/PID pair was left in `%TEMP%` for stale-PID detection to clean up later.

`stop()` now sends `GenerateConsoleCtrlEvent(CTRL_BREAK_EVENT, pid)` to the child's process group (which is exactly why `start()` passes `CREATE_NEW_PROCESS_GROUP`), waits up to 5 s for the process to exit, and only then falls back to `TerminateProcess` (plus a short wait, so a caller that restarts immediately does not race the singleton lock).

Being honest about the limits, as the docstring in the code also is:

- `GenerateConsoleCtrlEvent` only reaches processes attached to *our* console, and the agent is launched `DETACHED_PROCESS` with no console at all. Delivery will usually fail. **The `TerminateProcess` fallback is the norm, not a corner case.**
- Even when the event lands, CPython maps `CTRL_BREAK` onto `SIGBREAK`, and `main._run_foreground()` currently installs handlers for `SIGINT`/`SIGTERM` only. Registering the existing handler for `SIGBREAK` is a one-line follow-up in `main.py`, which another PR in this batch owns, so it is deliberately not included here.

Two smaller correctness fixes came along: `get_existing_instance_pid()` can return `-1` ("running, PID unknown") and that sentinel was being passed to `OpenProcess`; and the process handle is now closed on every exit path (`finally`), including when `TerminateProcess` raises.

### 2. `_needs_reinstall()` actually detects a stale binary (#14)

It was hardcoded `return False` despite the comment above it claiming the opposite, so the reinstall branch in `start()` was dead code and the scheduled task kept launching the old executable after an upgrade or a move.

It now runs `schtasks /Query /TN <name> /XML` and compares the task's Exec action against what `get_service_args()` would produce, mirroring how the macOS manager compares plist `ProgramArguments`.

Details that matter:

- Output is read as **bytes**, not `text=True` — schtasks emits UTF-16, and the decoder handles UTF-16 with/without BOM, UTF-8, and cp1252.
- The XML declaration is stripped before parsing, because ElementTree rejects `str` input carrying an encoding declaration.
- Element lookups use the `{*}` namespace wildcard, so the Task Scheduler namespace/schema version does not need to be hardcoded.
- `Command` and `Arguments` are flattened into one canonical command line before comparing (quotes dropped, whitespace collapsed, separators unified, case folded). schtasks decides where to split the `/TR` string we hand it; comparing the fields separately risked treating an unsplit command line as stale and reinstalling on **every** start.
- **Unknown state returns `False`**, not `True`. `start()` reacts to `True` by stopping and reinstalling, so an unreadable or unparseable query must not trigger a reinstall loop. (The macOS equivalent returns `True` there; that asymmetry is intentional and documented in the docstring.)

`start()`'s reinstall branch now also checks the results of `stop()`/`install()` instead of discarding them, so it cannot launch a second instance on top of one it failed to stop.

### 3. Service log is opened as utf-8 (part of #12)

`open(self._log_path, "a")` had no encoding, so the detached child's stdout/stderr landed in a file bound to the locale codepage (cp1252), and any emoji or CJK clipboard text raised `UnicodeEncodeError` inside a receive callback.

- The handle is now opened with `encoding="utf-8", errors="replace"`.
- The child also gets `PYTHONIOENCODING=utf-8:replace` in its environment. This is the part that actually fixes the child: the parent's `open()` encoding never reaches it — the child derives its own `sys.stdout` encoding from the environment, because the stream is a file rather than a console. (A PyInstaller-frozen child may run with an isolated config that ignores `PYTHON*` vars; there the runtime hook remains the backstop. The env is a copy of the parent's, so nothing else about the child's environment changes.)
- The handle was also opened and never closed. It is now wrapped in `with` — `CreateProcess` duplicates it into the child, so closing the parent's copy right after `Popen` returns is safe.

This is only the service-log half of #12; `main.py`'s `logging.FileHandler` and the non-ASCII glyphs are a separate PR in this batch.

## Testing

`tests/unit/test_windows_service.py` — 37 new tests, all mock-only. `subprocess.run`/`Popen`, `kernel32`, and `builtins.open` are all patched; nothing installs, starts, or stops a real service, and nothing binds a port.

- **`_needs_reinstall`**: matching task, stale exe path, dev-mode vs frozen args, changed flags, quoting/case/separator equivalence, unsplit command line, UTF-16 with and without BOM, UTF-8, `str` input with an encoding declaration, namespace-less XML, non-Exec (ComHandler) action, truncated XML, garbage bytes, empty output, non-zero exit, and `schtasks` missing — the last six all asserting `False`.
- **`stop()`**: not running, PID unknown, graceful success (asserts `TerminateProcess` is *not* called), the exact call ordering for the fallback path, undeliverable CTRL_BREAK skipping the graceful wait, `OpenProcess` failure, handle closed when `TerminateProcess` raises, and kernel32 unavailable.
- **`start()`**: log opened `"a"` + `encoding="utf-8"` + `errors="replace"`, `PYTHONIOENCODING` in the child env, handle closed in the parent, `CREATE_NEW_PROCESS_GROUP`/`DETACHED_PROCESS` still set (the stop path depends on the former), and all three branches of the reinstall check.

`_get_kernel32()` was extracted as a method precisely so these tests can substitute a mock — `ctypes.windll` does not exist off Windows. It returns a private `WinDLL` instance rather than the shared `ctypes.windll.kernel32` so that declaring `argtypes`/`restype` (HANDLEs must be pointer-sized, not `c_int`) cannot change how `common/singleton.py` calls the same functions.

Verified against the pre-change file: 21 of the 37 tests fail on the old implementation.

## Not verified

**This is Windows code edited from a macOS host — none of these code paths were executed.** `pywin32` will not install here, there is no Task Scheduler, and `ctypes.windll` does not exist. What was actually run:

- `python -m py_compile` on both changed files — clean
- full suite: **124 passed** (87 before this change, 37 new), no regressions
- `ruff check` and `mypy` on the changed file — clean (the repo is not lint-clean overall; these two files are)
- `black` was deliberately not applied: the repo is not black-formatted (39 files would be reformatted), so the existing style is preserved

No system-level e2e was run: `test_service_e2e.py` mutates real Task Scheduler/launchd state, and it cannot exercise Windows paths on this host anyway.
