### PR TITLE
Fix Windows clipboard lock hogging, PNG-registration lock leak, and received-image echo

### DIFF
--- a/src/yank/platform/windows/clipboard.py
+++ b/src/yank/platform/windows/clipboard.py
@@ -46,7 +46,61 @@ logger = logging.getLogger(__name__)
 CF_HDROP = 15  # File list format
 CF_DIB = 8     # Device Independent Bitmap
 CF_DIBV5 = 17  # DIB v5 (with alpha)
-CF_PNG = None  # Will be registered dynamically
+
+
+def _get_clipboard_sequence_number() -> Optional[int]:
+    """
+    Read the Windows clipboard sequence number.
+
+    Unlike OpenClipboard(), GetClipboardSequenceNumber() takes no clipboard lock,
+    so it is cheap enough to call on every poll. The value is bumped by the OS
+    every time any process changes the clipboard contents.
+
+    Returns:
+        Current sequence number, or None if it could not be read. The API returns
+        0 on failure (for example without WINSTA_ACCESSCLIPBOARD access), in which
+        case callers should fall back to inspecting the clipboard directly.
+    """
+    if not HAS_WIN32:
+        return None
+
+    try:
+        get_sequence = windll.user32.GetClipboardSequenceNumber
+        get_sequence.argtypes = []
+        get_sequence.restype = UINT
+        return get_sequence() or None
+    except Exception as e:
+        logger.debug(f"Could not read clipboard sequence number: {e}")
+        return None
+
+
+def _register_png_format() -> Optional[int]:
+    """
+    Register the "PNG" clipboard format.
+
+    Returns:
+        The registered format id, or None if it could not be registered.
+    """
+    try:
+        win32clipboard.OpenClipboard()
+    except Exception as e:
+        logger.debug(f"Could not open clipboard to register PNG format: {e}")
+        return None
+
+    try:
+        fmt = win32clipboard.RegisterClipboardFormat("PNG")
+    except Exception as e:
+        logger.debug(f"Could not register PNG clipboard format: {e}")
+        fmt = None
+    finally:
+        # Must always run: leaking the global clipboard lock here would break
+        # copy/paste in every application on the machine until we exit.
+        try:
+            win32clipboard.CloseClipboard()
+        except Exception as e:
+            logger.debug(f"Could not close clipboard after PNG registration: {e}")
+
+    return fmt or None
 
 
 class WindowsClipboardMonitor:
@@ -98,9 +152,14 @@ class WindowsClipboardMonitor:
 
         self._running = False
         self._monitor_thread: Optional[threading.Thread] = None
-        self._last_clipboard_hash: Optional[str] = None
+        # File lists and image data are hashed differently, so they need separate
+        # slots. Sharing one field made a received image echo back to the peer:
+        # set_clipboard_files() stored the file-list hash, then the image branch
+        # compared the image-data hash against it and never matched.
+        self._last_file_hash: Optional[str] = None
+        self._last_image_hash: Optional[str] = None
         self._last_text_hash: Optional[str] = None
-        self._last_change_count: int = 0
+        self._last_change_count: Optional[int] = None
         self._lock = threading.Lock()
 
         # Track files/text we've received to avoid loops
@@ -109,20 +168,18 @@ class WindowsClipboardMonitor:
         self._received_text_hash: Optional[str] = None
         self._received_text_lock = threading.Lock()
 
-        # Register PNG clipboard format
-        global CF_PNG
-        try:
-            win32clipboard.OpenClipboard()
-            CF_PNG = win32clipboard.RegisterClipboardFormat("PNG")
-            win32clipboard.CloseClipboard()
-        except:
-            CF_PNG = None
-    
+        # Register PNG clipboard format (per instance, not a mutated module global)
+        self._cf_png: Optional[int] = _register_png_format()
+
     def start(self):
         """Start monitoring the clipboard"""
         if self._running:
             return
-        
+
+        # Seed the sequence number so whatever was already on the clipboard before
+        # we started is not broadcast to the peer (same as the macOS monitor).
+        self._last_change_count = _get_clipboard_sequence_number()
+
         self._running = True
         self._monitor_thread = threading.Thread(target=self._monitor_loop, daemon=True)
         self._monitor_thread.start()
@@ -153,6 +210,17 @@ class WindowsClipboardMonitor:
     
     def _check_clipboard(self):
         """Check clipboard for file, image, or text changes"""
+        # Lock-free change detection first. OpenClipboard() takes the *global*
+        # clipboard lock, so taking it ~3x/second (just to ask which formats are
+        # present) makes copy/paste intermittently fail in other applications.
+        # The sequence number needs no lock, so only open when it actually moved.
+        sequence = _get_clipboard_sequence_number()
+        if sequence is not None:
+            with self._lock:
+                if sequence == self._last_change_count:
+                    return
+                self._last_change_count = sequence
+
         try:
             win32clipboard.OpenClipboard()
 
@@ -163,7 +231,8 @@ class WindowsClipboardMonitor:
                 elif self.sync_images and HAS_PIL and (
                         win32clipboard.IsClipboardFormatAvailable(CF_DIB) or
                         win32clipboard.IsClipboardFormatAvailable(CF_DIBV5) or
-                        (CF_PNG and win32clipboard.IsClipboardFormatAvailable(CF_PNG))):
+                        (self._cf_png and
+                         win32clipboard.IsClipboardFormatAvailable(self._cf_png))):
                     self._handle_image()
                 elif self.sync_text and win32clipboard.IsClipboardFormatAvailable(win32con.CF_UNICODETEXT):
                     self._handle_text()
@@ -190,9 +259,9 @@ class WindowsClipboardMonitor:
         
         # Check if this is new
         with self._lock:
-            if clipboard_hash == self._last_clipboard_hash:
+            if clipboard_hash == self._last_file_hash:
                 return
-            self._last_clipboard_hash = clipboard_hash
+            self._last_file_hash = clipboard_hash
         
         # Check if these are files we just received (avoid loops)
         with self._received_files_lock:
@@ -218,31 +287,31 @@ class WindowsClipboardMonitor:
         image_format = None
         
         # Try PNG first (best quality, supports transparency)
-        if CF_PNG and win32clipboard.IsClipboardFormatAvailable(CF_PNG):
+        if self._cf_png and win32clipboard.IsClipboardFormatAvailable(self._cf_png):
             try:
-                image_data = win32clipboard.GetClipboardData(CF_PNG)
+                image_data = win32clipboard.GetClipboardData(self._cf_png)
                 image_format = 'png'
-            except:
+            except Exception:
                 pass
-        
+
         # Fall back to DIB
         if not image_data and win32clipboard.IsClipboardFormatAvailable(CF_DIB):
             try:
                 image_data = win32clipboard.GetClipboardData(CF_DIB)
                 image_format = 'dib'
-            except:
+            except Exception:
                 pass
-        
+
         if not image_data:
             return
-        
+
         # Create hash to detect changes
-        data_hash = hashlib.md5(image_data[:4096] if len(image_data) > 4096 else image_data).hexdigest()
-        
+        data_hash = self._hash_image_data(image_data)
+
         with self._lock:
-            if data_hash == self._last_clipboard_hash:
+            if data_hash == self._last_image_hash:
                 return
-            self._last_clipboard_hash = data_hash
+            self._last_image_hash = data_hash
         
         # Convert to image file
         try:
@@ -333,7 +402,7 @@ class WindowsClipboardMonitor:
         """Handle text clipboard data"""
         try:
             text = win32clipboard.GetClipboardData(win32con.CF_UNICODETEXT)
-        except:
+        except Exception:
             return
 
         if not text or not text.strip():
@@ -362,6 +431,11 @@ class WindowsClipboardMonitor:
         """Create a hash of file list for change detection"""
         content = '|'.join(sorted(str(p) for p in file_paths))
         return hashlib.md5(content.encode()).hexdigest()
+
+    @staticmethod
+    def _hash_image_data(image_data: bytes) -> str:
+        """Create a hash of raw image data for change detection"""
+        return hashlib.md5(image_data[:4096]).hexdigest()
 
     def set_clipboard_text(self, text: str):
         """
@@ -414,7 +488,7 @@ class WindowsClipboardMonitor:
         
         # Update our hash to avoid re-sending
         with self._lock:
-            self._last_clipboard_hash = self._hash_file_list(file_paths)
+            self._last_file_hash = self._hash_file_list(file_paths)
         
         # Check if it's a single image file - put as image data too
         if len(file_paths) == 1 and HAS_PIL:
@@ -476,19 +550,30 @@ class WindowsClipboardMonitor:
             png_output = io.BytesIO()
             Image.open(image_path).save(png_output, 'PNG')
             png_data = png_output.getvalue()
-            
+
+            # Remember the hash of the image bytes we are about to publish, hashed
+            # exactly the way _handle_image() will hash them when it reads them
+            # back. Without this the next poll re-sends the image we just received
+            # whenever sync_files is off and sync_images is on (issue #16).
+            # This has to happen *before* the data hits the clipboard: the monitor
+            # thread can poll in between, and would find an unrecognised image.
+            with self._lock:
+                self._last_image_hash = self._hash_image_data(
+                    png_data if self._cf_png else dib_data
+                )
+
             # Set clipboard with multiple formats
             win32clipboard.OpenClipboard()
             try:
                 win32clipboard.EmptyClipboard()
-                
+
                 # Set DIB (most compatible)
                 win32clipboard.SetClipboardData(CF_DIB, dib_data)
-                
+
                 # Set PNG (better quality)
-                if CF_PNG:
-                    win32clipboard.SetClipboardData(CF_PNG, png_data)
-                
+                if self._cf_png:
+                    win32clipboard.SetClipboardData(self._cf_png, png_data)
+
                 # Also set as file for file-based paste
                 import struct
                 dropfiles_size = 20
@@ -590,6 +675,11 @@ def get_clipboard_files() -> List[Path]:
             data = win32clipboard.GetClipboardData(CF_HDROP)
             if data:
                 return [Path(f) for f in data if Path(f).exists()]
+
+            # CF_HDROP was advertised but held nothing usable. Return explicitly:
+            # callers unpack this as a list, so falling off the end here (and
+            # returning None) would give them a TypeError.
+            return []
         finally:
             win32clipboard.CloseClipboard()
     except Exception as e:

--- a/src/yank/platform/windows/clipboard.py
+++ b/src/yank/platform/windows/clipboard.py
@@ -219,12 +219,21 @@ class WindowsClipboardMonitor:
             with self._lock:
                 if sequence == self._last_change_count:
                     return
-                self._last_change_count = sequence
 
         try:
             win32clipboard.OpenClipboard()
 
             try:
+                # Consume the change only now that the open succeeded. Doing it
+                # before would drop the copy for good whenever the source app is
+                # still holding the clipboard - the exact contention this method
+                # is trying to be a good citizen about. Doing it after dispatch
+                # would instead let a handler that raises every time re-open the
+                # clipboard on every poll, which is the lock hogging we just fixed.
+                if sequence is not None:
+                    with self._lock:
+                        self._last_change_count = sequence
+
                 # Priority: Files first, then images, then text
                 if self.sync_files and win32clipboard.IsClipboardFormatAvailable(CF_HDROP):
                     self._handle_files()

--- a/tests/unit/test_windows_clipboard.py
+++ b/tests/unit/test_windows_clipboard.py
@@ -1,0 +1,474 @@
+"""
+Unit tests for the Windows clipboard monitor.
+
+These tests do NOT run any Win32 code. The module under test cannot even be
+imported off Windows (``import win32clipboard`` and ``from ctypes import windll``
+both fail, which flips ``HAS_WIN32`` to False and makes the constructor raise), so
+every test installs fake pywin32 modules into ``sys.modules`` plus a fake
+``ctypes.windll`` and then imports the module fresh. That exercises the module's
+logic - polling, hashing, lock discipline - against an in-memory clipboard while
+never touching a real one.
+"""
+
+import importlib
+import io
+import sys
+import time
+from types import ModuleType, SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+MODULE_NAME = "yank.platform.windows.clipboard"
+PACKAGE_NAME = "yank.platform.windows"
+
+# Real Win32 clipboard format ids used by the module under test
+CF_HDROP = 15
+CF_DIB = 8
+CF_UNICODETEXT = 13
+
+
+class FakeSequenceNumber:
+    """Stand-in for user32.GetClipboardSequenceNumber."""
+
+    def __init__(self, value: int = 1000):
+        self.value = value
+        self.call_count = 0
+
+    def bump(self, by: int = 1) -> None:
+        self.value += by
+
+    def __call__(self) -> int:
+        self.call_count += 1
+        return self.value
+
+
+class FakeWin32Clipboard:
+    """
+    Minimal in-memory stand-in for the win32clipboard module.
+
+    Tracks open/close calls so tests can assert the monitor is not grabbing the
+    global clipboard lock, and that it always releases it.
+    """
+
+    def __init__(self, png_format: int = 49999):
+        self.contents: dict = {}
+        self.png_format = png_format
+        self.register_error = None
+        self.open_error = None
+        self.calls: list = []
+        self.open_count = 0
+        self.close_count = 0
+        self.is_open = False
+        self.double_open = False
+
+    def reset_counts(self) -> None:
+        self.calls = []
+        self.open_count = 0
+        self.close_count = 0
+
+    # --- win32clipboard API surface --------------------------------------
+    def OpenClipboard(self, hwnd=None):
+        self.calls.append("OpenClipboard")
+        if self.open_error is not None:
+            raise self.open_error
+        if self.is_open:
+            self.double_open = True
+        self.is_open = True
+        self.open_count += 1
+
+    def CloseClipboard(self):
+        self.calls.append("CloseClipboard")
+        self.close_count += 1
+        self.is_open = False
+
+    def EmptyClipboard(self):
+        self.calls.append("EmptyClipboard")
+        self.contents.clear()
+
+    def RegisterClipboardFormat(self, name):
+        self.calls.append("RegisterClipboardFormat")
+        if self.register_error is not None:
+            raise self.register_error
+        return self.png_format
+
+    def IsClipboardFormatAvailable(self, fmt):
+        return fmt in self.contents
+
+    def GetClipboardData(self, fmt):
+        if fmt not in self.contents:
+            raise RuntimeError(f"clipboard format {fmt} not available")
+        return self.contents[fmt]
+
+    def SetClipboardData(self, fmt, data):
+        self.contents[fmt] = data
+
+    def SetClipboardText(self, text, fmt=None):
+        self.contents[CF_UNICODETEXT] = text
+
+
+@pytest.fixture
+def win_env(monkeypatch):
+    """Import the Windows clipboard module against fake pywin32 bindings."""
+    import ctypes
+
+    clipboard = FakeWin32Clipboard()
+    sequence = FakeSequenceNumber()
+
+    win32con = ModuleType("win32con")
+    win32con.CF_UNICODETEXT = CF_UNICODETEXT
+
+    fakes = {
+        "win32clipboard": clipboard,
+        "win32con": win32con,
+        "win32api": MagicMock(name="win32api"),
+        "win32gui": MagicMock(name="win32gui"),
+        "pythoncom": MagicMock(name="pythoncom"),
+    }
+    for name, fake in fakes.items():
+        monkeypatch.setitem(sys.modules, name, fake)
+
+    # ctypes.windll only exists on Windows
+    monkeypatch.setattr(
+        ctypes,
+        "windll",
+        SimpleNamespace(user32=SimpleNamespace(GetClipboardSequenceNumber=sequence)),
+        raising=False,
+    )
+
+    saved = {name: sys.modules.pop(name, None) for name in (MODULE_NAME, PACKAGE_NAME)}
+    module = importlib.import_module(MODULE_NAME)
+    assert module.HAS_WIN32, "fake pywin32 modules were not picked up"
+
+    yield SimpleNamespace(module=module, clipboard=clipboard, sequence=sequence)
+
+    for name, original in saved.items():
+        sys.modules.pop(name, None)
+        if original is not None:
+            sys.modules[name] = original
+
+
+def make_monitor(win_env, tmp_path, **kwargs):
+    """Build a monitor and forget the clipboard calls made while constructing it."""
+    kwargs.setdefault("temp_dir", tmp_path / "clipboard-sync")
+    monitor = win_env.module.WindowsClipboardMonitor(**kwargs)
+    win_env.clipboard.reset_counts()
+    return monitor
+
+
+def make_png(path, color=(10, 120, 200)):
+    from PIL import Image
+
+    Image.new("RGB", (8, 8), color).save(path, "PNG")
+    return path
+
+
+def png_bytes(color=(250, 20, 20)):
+    from PIL import Image
+
+    buffer = io.BytesIO()
+    Image.new("RGB", (8, 8), color).save(buffer, "PNG")
+    return buffer.getvalue()
+
+
+class TestSequenceNumberGate:
+    """Issue #13: OpenClipboard() must not be called on every poll."""
+
+    def test_unchanged_sequence_number_never_opens_the_clipboard(self, win_env, tmp_path):
+        monitor = make_monitor(win_env, tmp_path)
+        monitor._last_change_count = win_env.sequence.value
+
+        for _ in range(5):
+            monitor._check_clipboard()
+
+        assert win_env.clipboard.open_count == 0
+        assert win_env.clipboard.calls == []
+        # The lock-free API is what got called instead
+        assert win_env.sequence.call_count == 5
+
+    def test_changed_sequence_number_opens_the_clipboard_once(self, win_env, tmp_path):
+        received = []
+        monitor = make_monitor(win_env, tmp_path, on_text_copied=received.append)
+        monitor._last_change_count = win_env.sequence.value
+        win_env.clipboard.contents[CF_UNICODETEXT] = "hello from the peer"
+
+        win_env.sequence.bump()
+        monitor._check_clipboard()
+        # Two further polls with no further change must not re-open
+        monitor._check_clipboard()
+        monitor._check_clipboard()
+
+        assert win_env.clipboard.open_count == 1
+        assert win_env.clipboard.close_count == 1
+        assert win_env.clipboard.is_open is False
+        assert received == ["hello from the peer"]
+
+    def test_each_new_change_opens_the_clipboard_again(self, win_env, tmp_path):
+        monitor = make_monitor(win_env, tmp_path)
+        monitor._last_change_count = win_env.sequence.value
+
+        for _ in range(3):
+            win_env.sequence.bump()
+            monitor._check_clipboard()
+
+        assert win_env.clipboard.open_count == 3
+        assert win_env.clipboard.close_count == 3
+
+    def test_falls_back_to_opening_when_sequence_number_is_unavailable(self, win_env, tmp_path):
+        monitor = make_monitor(win_env, tmp_path)
+        # GetClipboardSequenceNumber returns 0 on failure
+        win_env.sequence.value = 0
+
+        monitor._check_clipboard()
+        monitor._check_clipboard()
+
+        assert win_env.module._get_clipboard_sequence_number() is None
+        assert win_env.clipboard.open_count == 2
+
+    def test_falls_back_to_opening_when_sequence_number_raises(self, win_env, tmp_path):
+        monitor = make_monitor(win_env, tmp_path)
+
+        def boom():
+            raise OSError("user32 unavailable")
+
+        win_env.module.windll.user32.GetClipboardSequenceNumber = boom
+
+        monitor._check_clipboard()
+
+        assert win_env.clipboard.open_count == 1
+
+    def test_start_seeds_sequence_number_and_ignores_preexisting_content(self, win_env, tmp_path):
+        sent = []
+        win_env.clipboard.contents[CF_UNICODETEXT] = "copied before yank started"
+        monitor = make_monitor(win_env, tmp_path, on_text_copied=sent.append, poll_interval=0.01)
+
+        monitor.start()
+        try:
+            time.sleep(0.05)
+        finally:
+            monitor.stop()
+
+        assert monitor._last_change_count == win_env.sequence.value
+        # Content the user copied before the daemon existed is not broadcast,
+        # and no poll took the global clipboard lock.
+        assert sent == []
+        assert win_env.clipboard.open_count == 0
+
+
+class TestPngFormatRegistration:
+    """Issue #13 (related): registration must never leak the clipboard lock."""
+
+    def test_successful_registration_opens_and_closes(self, win_env, tmp_path):
+        monitor = win_env.module.WindowsClipboardMonitor(temp_dir=tmp_path)
+
+        assert monitor._cf_png == win_env.clipboard.png_format
+        assert win_env.clipboard.open_count == 1
+        assert win_env.clipboard.close_count == 1
+        assert win_env.clipboard.is_open is False
+
+    def test_registration_failure_still_closes_the_clipboard(self, win_env, tmp_path):
+        win_env.clipboard.register_error = RuntimeError("RegisterClipboardFormat failed")
+
+        monitor = win_env.module.WindowsClipboardMonitor(temp_dir=tmp_path)
+
+        assert monitor._cf_png is None
+        # The whole point: the lock is released even though registration threw
+        assert win_env.clipboard.close_count == 1
+        assert win_env.clipboard.is_open is False
+        assert win_env.clipboard.calls == [
+            "OpenClipboard",
+            "RegisterClipboardFormat",
+            "CloseClipboard",
+        ]
+
+    def test_registration_does_not_close_when_open_failed(self, win_env, tmp_path):
+        win_env.clipboard.open_error = RuntimeError("clipboard busy")
+
+        monitor = win_env.module.WindowsClipboardMonitor(temp_dir=tmp_path)
+
+        assert monitor._cf_png is None
+        assert win_env.clipboard.close_count == 0
+
+    def test_keyboard_interrupt_is_not_swallowed(self, win_env, tmp_path):
+        """The old bare `except:` also ate KeyboardInterrupt/SystemExit."""
+        win_env.clipboard.register_error = KeyboardInterrupt()
+
+        with pytest.raises(KeyboardInterrupt):
+            win_env.module.WindowsClipboardMonitor(temp_dir=tmp_path)
+
+        # ...and it still released the lock on the way out
+        assert win_env.clipboard.close_count == 1
+        assert win_env.clipboard.is_open is False
+
+    def test_registration_is_per_instance_not_a_module_global(self, win_env, tmp_path):
+        first = win_env.module.WindowsClipboardMonitor(temp_dir=tmp_path)
+        win_env.clipboard.register_error = RuntimeError("nope")
+        second = win_env.module.WindowsClipboardMonitor(temp_dir=tmp_path)
+
+        assert first._cf_png == win_env.clipboard.png_format
+        assert second._cf_png is None
+        assert not hasattr(win_env.module, "CF_PNG")
+
+
+class TestFileAndImageHashSplit:
+    """Issue #16 (Windows half): a file-list hash must never gate an image."""
+
+    def test_hashes_live_in_separate_fields(self, win_env, tmp_path):
+        monitor = make_monitor(win_env, tmp_path)
+        doc = tmp_path / "notes.txt"
+        doc.write_text("hi")
+
+        monitor.set_clipboard_files([doc])
+
+        assert monitor._last_file_hash == monitor._hash_file_list([doc])
+        assert monitor._last_image_hash is None
+        assert not hasattr(monitor, "_last_clipboard_hash")
+
+    def test_received_image_does_not_echo_back_when_sync_files_is_off(self, win_env, tmp_path):
+        pytest.importorskip("PIL")
+        sent = []
+        monitor = make_monitor(
+            win_env,
+            tmp_path,
+            on_files_copied=sent.append,
+            sync_files=False,
+            sync_images=True,
+        )
+        monitor._last_change_count = win_env.sequence.value
+        image = make_png(tmp_path / "received.png")
+
+        # Peer sends an image; we inject it into the clipboard
+        monitor.set_clipboard_files([image])
+        # The remembered hash is over the exact bytes the next poll will read back
+        assert monitor._last_image_hash == monitor._hash_image_data(
+            win_env.clipboard.contents[monitor._cf_png]
+        )
+        # Our own write bumps the sequence number, so the next poll does look
+        win_env.sequence.bump()
+
+        monitor._check_clipboard()
+
+        assert sent == [], "received image was sent straight back to the peer"
+
+    def test_received_image_does_not_echo_back_via_the_dib_fallback(self, win_env, tmp_path):
+        """Same guarantee when the PNG format could not be registered."""
+        pytest.importorskip("PIL")
+        sent = []
+        win_env.clipboard.register_error = RuntimeError("no PNG format")
+        monitor = make_monitor(
+            win_env,
+            tmp_path,
+            on_files_copied=sent.append,
+            sync_files=False,
+            sync_images=True,
+        )
+        assert monitor._cf_png is None
+        monitor._last_change_count = win_env.sequence.value
+
+        monitor.set_clipboard_files([make_png(tmp_path / "received.png")])
+        win_env.sequence.bump()
+
+        monitor._check_clipboard()
+
+        # The image went out as CF_DIB only, so the recorded hash must be over the
+        # DIB bytes rather than the PNG ones
+        assert monitor._last_image_hash == monitor._hash_image_data(
+            win_env.clipboard.contents[CF_DIB]
+        )
+        assert sent == []
+
+    def test_a_genuinely_new_image_is_still_sent(self, win_env, tmp_path):
+        pytest.importorskip("PIL")
+        sent = []
+        monitor = make_monitor(
+            win_env,
+            tmp_path,
+            on_files_copied=sent.append,
+            sync_files=False,
+            sync_images=True,
+        )
+        monitor._last_change_count = win_env.sequence.value
+        monitor.set_clipboard_files([make_png(tmp_path / "received.png")])
+
+        # The user now copies a different image
+        win_env.clipboard.contents[monitor._cf_png] = png_bytes()
+        win_env.sequence.bump()
+
+        monitor._check_clipboard()
+
+        assert len(sent) == 1
+        assert sent[0][0].suffix == ".png"
+        assert sent[0][0].parent == monitor.temp_dir
+
+    def test_received_files_do_not_echo_back(self, win_env, tmp_path):
+        sent = []
+        monitor = make_monitor(win_env, tmp_path, on_files_copied=sent.append)
+        monitor._last_change_count = win_env.sequence.value
+        doc = tmp_path / "notes.txt"
+        doc.write_text("hi")
+
+        monitor.set_clipboard_files([doc])
+        # pywin32 hands back a tuple of paths for CF_HDROP, not the DROPFILES blob
+        win_env.clipboard.contents[CF_HDROP] = (str(doc),)
+        win_env.sequence.bump()
+
+        monitor._check_clipboard()
+
+        assert sent == []
+
+    def test_new_files_are_sent(self, win_env, tmp_path):
+        sent = []
+        monitor = make_monitor(win_env, tmp_path, on_files_copied=sent.append)
+        monitor._last_change_count = win_env.sequence.value
+        doc = tmp_path / "notes.txt"
+        doc.write_text("hi")
+
+        win_env.clipboard.contents[CF_HDROP] = (str(doc),)
+        win_env.sequence.bump()
+        monitor._check_clipboard()
+
+        assert sent == [[doc]]
+
+    def test_injected_text_is_not_sent_back(self, win_env, tmp_path):
+        sent = []
+        monitor = make_monitor(win_env, tmp_path, on_text_copied=sent.append)
+        monitor._last_change_count = win_env.sequence.value
+
+        monitor.set_clipboard_text("from the peer")
+        win_env.sequence.bump()
+        monitor._check_clipboard()
+
+        assert sent == []
+
+
+class TestGetClipboardFiles:
+    """Issue #17: the function must always hand back a list."""
+
+    def test_returns_empty_list_when_hdrop_data_is_falsy(self, win_env):
+        # CF_HDROP is advertised but holds nothing usable
+        win_env.clipboard.contents[CF_HDROP] = ()
+
+        result = win_env.module.get_clipboard_files()
+
+        assert result == []
+        assert isinstance(result, list)
+        assert win_env.clipboard.close_count == 1
+        assert win_env.clipboard.is_open is False
+
+    def test_returns_empty_list_when_hdrop_is_absent(self, win_env):
+        result = win_env.module.get_clipboard_files()
+
+        assert result == []
+        assert win_env.clipboard.close_count == 1
+
+    def test_returns_only_existing_paths(self, win_env, tmp_path):
+        existing = tmp_path / "there.txt"
+        existing.write_text("x")
+        win_env.clipboard.contents[CF_HDROP] = (str(existing), str(tmp_path / "gone.txt"))
+
+        assert win_env.module.get_clipboard_files() == [existing]
+
+    def test_returns_empty_list_when_the_clipboard_is_locked(self, win_env):
+        win_env.clipboard.open_error = RuntimeError("clipboard busy")
+
+        assert win_env.module.get_clipboard_files() == []

--- a/tests/unit/test_windows_clipboard.py
+++ b/tests/unit/test_windows_clipboard.py
@@ -56,6 +56,8 @@ class FakeWin32Clipboard:
         self.png_format = png_format
         self.register_error = None
         self.open_error = None
+        # Formats that are advertised but blow up on read (delayed rendering)
+        self.get_errors: dict = {}
         self.calls: list = []
         self.open_count = 0
         self.close_count = 0
@@ -96,6 +98,8 @@ class FakeWin32Clipboard:
         return fmt in self.contents
 
     def GetClipboardData(self, fmt):
+        if fmt in self.get_errors:
+            raise self.get_errors[fmt]
         if fmt not in self.contents:
             raise RuntimeError(f"clipboard format {fmt} not available")
         return self.contents[fmt]
@@ -236,6 +240,69 @@ class TestSequenceNumberGate:
         monitor._check_clipboard()
 
         assert win_env.clipboard.open_count == 1
+
+    def test_a_failed_open_does_not_consume_the_change(self, win_env, tmp_path):
+        """
+        The sequence number must only be committed once the open succeeded.
+
+        Committing it up front would drop the copy permanently whenever the
+        source application is still holding the clipboard - which is precisely
+        the contention this polling change is meant to be gentle about.
+        """
+        received = []
+        monitor = make_monitor(win_env, tmp_path, on_text_copied=received.append)
+        monitor._last_change_count = win_env.sequence.value
+        text = "copied while another app held the lock"
+        win_env.clipboard.contents[CF_UNICODETEXT] = text
+
+        # The source app bumps the sequence number, then keeps the lock a while
+        win_env.sequence.bump()
+        win_env.clipboard.open_error = RuntimeError("clipboard busy")
+        monitor._check_clipboard()
+        assert received == []
+
+        # It lets go: the copy must still be delivered, not silently swallowed
+        win_env.clipboard.open_error = None
+        monitor._check_clipboard()
+
+        assert received == [text]
+
+    def test_a_failed_open_recovers_on_a_later_poll(self, win_env, tmp_path):
+        received = []
+        monitor = make_monitor(win_env, tmp_path, on_text_copied=received.append)
+        monitor._last_change_count = win_env.sequence.value
+        win_env.clipboard.contents[CF_UNICODETEXT] = "eventually consistent"
+
+        win_env.sequence.bump()
+        win_env.clipboard.open_error = RuntimeError("clipboard busy")
+        monitor._check_clipboard()
+        win_env.clipboard.open_error = None
+
+        for _ in range(10):
+            monitor._check_clipboard()
+
+        # Delivered exactly once across the recovery polls
+        assert received == ["eventually consistent"]
+
+    def test_a_handler_that_keeps_raising_does_not_reopen_every_poll(self, win_env, tmp_path):
+        """
+        The flip side: committing *after* dispatch would let one unreadable
+        clipboard item re-take the global lock ~3x/second forever.
+        """
+        sent = []
+        monitor = make_monitor(win_env, tmp_path, on_files_copied=sent.append)
+        monitor._last_change_count = win_env.sequence.value
+        win_env.clipboard.contents[CF_HDROP] = (str(tmp_path / "whatever.txt"),)
+        win_env.clipboard.get_errors[CF_HDROP] = RuntimeError("delayed rendering failed")
+
+        win_env.sequence.bump()
+        for _ in range(5):
+            monitor._check_clipboard()
+
+        assert sent == []
+        # One attempt for the one change, not one per poll
+        assert win_env.clipboard.open_count == 1
+        assert win_env.clipboard.close_count == 1
 
     def test_start_seeds_sequence_number_and_ignores_preexisting_content(self, win_env, tmp_path):
         sent = []


### PR DESCRIPTION
Four fixes in `src/yank/platform/windows/clipboard.py`, plus the first test coverage this module has ever had.

Closes #13
Closes #17

This also fixes the Windows half of #16 (the macOS half of that issue is handled in a separate PR, so #16 stays open).

## ⚠️ The Windows code paths were not executed

This was developed on a macOS host. pywin32 cannot be installed here, so **none of the changed code was actually run against a real Windows clipboard**. Verification was:

- `python -m py_compile src/yank/platform/windows/clipboard.py`
- the full `pytest` suite green (87 pre-existing + 22 new = 109 passed)
- new unit tests that inject fake `win32clipboard` / `win32con` / `win32api` / `win32gui` / `pythoncom` modules and a fake `ctypes.windll` into `sys.modules`, then import the module fresh

The fake-clipboard tests pin behaviour and logic, not Win32 semantics. **Someone should smoke-test this on a real Windows box before release** — in particular that `GetClipboardSequenceNumber` really does advance for the copies we care about.

Each bug below was reproduced against the pre-fix module using the same fakes, so these are demonstrated regressions rather than speculative ones.

## 1. The monitor took the global clipboard lock ~3x/second (#13)

`_check_clipboard()` called `win32clipboard.OpenClipboard()` on every poll purely to ask `IsClipboardFormatAvailable` which formats were present. `OpenClipboard()` takes the *global* clipboard lock, so with `poll_interval = 0.3` we were grabbing it roughly three times a second, forever. That is the classic cause of "Ctrl+C sporadically does nothing" in other applications.

`GetClipboardSequenceNumber()` (user32) needs no lock at all. The class already declared `self._last_change_count` and never used it — the design was half-written. The check is now gated on it and only opens the clipboard when the number actually moved, mirroring how the macOS monitor polls `NSPasteboard.changeCount()`.

Measured against the pre-fix module with the fakes: **5 idle polls → 5 `OpenClipboard()` calls. After: 0.**

If `GetClipboardSequenceNumber` is unavailable (it returns 0 on failure, e.g. without `WINSTA_ACCESSCLIPBOARD`) or throws, the code degrades to the old always-open behaviour rather than going blind. Both fallbacks are tested.

### First poll after `start()`

`start()` now seeds `_last_change_count` with the current sequence number, so **content already on the clipboard when the daemon starts is not sent**. That is a deliberate behaviour change and it matches the macOS monitor, which seeds `changeCount()` in `start()`.

The alternative — sending whatever is on the clipboard at startup — is worse: every daemon start, service restart or crash-restart would push the local clipboard to the peer and overwrite whatever the peer had, without the user copying anything. Missing pre-existing content costs the user one re-copy; spuriously broadcasting it silently clobbers the other machine.

### When the change is committed (review fix, commit 3441b5a)

The first cut of this PR committed `_last_change_count = sequence` **before** calling `OpenClipboard()`. Review caught that this drops the copy for good if the open throws — which is exactly the contention case this PR exists to be gentle about, since a source app publishing many formats can hold the clipboard for tens of milliseconds after the sequence number has already been bumped by its first `SetClipboardData`. Master retried on every poll and recovered; that first cut did not. It was a regression in the situation the PR is meant to improve.

The commit now happens **after a successful open, before dispatch**:

- *Before the open* sits only the lock-free comparison, which still short-circuits — idle polls never take the global clipboard lock, which is the whole point of the change.
- *After a successful open* means a failed open leaves the change pending, so the next poll picks it up.
- *Not after dispatch*, deliberately: a handler that raises every time would then re-open the clipboard on every poll forever, which is precisely the lock hogging being fixed here. The tradeoff is that one clipboard item that consistently fails to read (e.g. delayed rendering the owner never satisfies) is attempted once rather than retried — the right side to err on, since the failure mode of the alternative is a permanent 3x/second lock grab.

Measured across the three module versions with the fake clipboard:

| scenario | master | first cut | now |
|---|---|---|---|
| copy recovered after a failed open | delivered | **dropped** | delivered |
| `OpenClipboard` calls, 5 idle polls | 5 | 0 | 0 |
| `OpenClipboard` calls, unreadable item × 5 polls | 5 | 1 | 1 |

Three regression tests pin this: recovery after a single failed open, recovery across ten subsequent polls (delivered exactly once, not repeatedly), and one permanently unreadable item producing one open rather than one per poll.

## 2. PNG registration could leak the system clipboard lock (#13, second part)

```python
try:
    win32clipboard.OpenClipboard()
    CF_PNG = win32clipboard.RegisterClipboardFormat("PNG")
    win32clipboard.CloseClipboard()
except:
    CF_PNG = None
```

If `RegisterClipboardFormat` threw after `OpenClipboard()` had already succeeded, `CloseClipboard()` never ran and the system clipboard stayed locked **for every application on the machine** until the process exited. Confirmed against the pre-fix module: register raises → `CloseClipboard` calls: 0. After: 1.

It is now a module-level `_register_png_format()` helper with `try/finally`, so the close always happens — and `CloseClipboard()` is only called if `OpenClipboard()` actually succeeded. The bare `except:` is now `except Exception:`, so `KeyboardInterrupt`/`SystemExit` propagate (there is a test for that, including that the lock is still released on the way out).

`CF_PNG` was a module-level global mutated from `__init__`. Nothing outside this file read it, so it is now the instance attribute `self._cf_png` — two monitors no longer stomp on each other and the value cannot leak between tests.

Note for a follow-up: `RegisterClipboardFormat` does not actually require the clipboard to be open at all, so the `OpenClipboard`/`CloseClipboard` pair around it could be dropped entirely. I kept it (correctly paired) to keep this diff to the reported bug.

## 3. Received images echoed back to the peer (Windows half of #16)

`_last_clipboard_hash` held *either* a file-list hash (written by `_handle_files` and `set_clipboard_files`) *or* an image-data hash (compared in `_handle_image`). With `sync_files=false` and `sync_images=true`, injecting a received image stored the **file-list** hash; the next poll took the **image** branch, hashed the image **data**, found no match, and sent the image straight back to the peer.

Reproduced against the pre-fix module: inject a received image with `sync_files=false` → the send callback fires. After the fix: it does not.

Split into `_last_file_hash` and `_last_image_hash`. Splitting the fields alone is not sufficient — `_last_image_hash` would just be `None` and the image would still go back — so `_set_clipboard_image_file()` now also records the hash of the bytes it publishes, hashed exactly the way `_handle_image()` will hash them when it reads them back (PNG bytes when the PNG format is registered, DIB bytes otherwise; both paths tested).

That record happens *before* the data hits the clipboard, deliberately: the monitor thread can poll in between and would otherwise find an image it does not recognise.

Existing loop prevention is preserved — the `_received_files` / `_received_text_hash` tracking and the file and text hash gates are untouched, and there are tests asserting injected text and injected files still do not echo, while genuinely new content still sends.

## 4. `get_clipboard_files()` (#17)

Honest finding: **the reported `None` return does not occur in the current code.** The issue says the function falls off the end after the `finally` block when `GetClipboardData` returns something falsy, but there is a function-level `return []` after the outer `except` that catches that path. I verified this against the pre-fix module with the fakes — falsy `CF_HDROP` data returns `[]`, not `None`.

So there is no `TypeError` to fix. What this PR does instead is make the contract local and explicit — an early `return []` in the branch itself rather than relying on control flow falling through two nested blocks, which is exactly the kind of thing that breaks silently in a later refactor — and pin it with tests covering falsy data, absent `CF_HDROP`, a locked clipboard, and filtering to paths that exist. Closing #17 on that basis; happy to reopen if the reporter hit the `TypeError` on a build that differs from `master`.

## Known issue left for a follow-up: the 4096-byte prefix hash

`_hash_image_data()` keeps master's behaviour of hashing only the first 4096 bytes of the image data. This PR does not change that — it is semantically identical to master, so it is not a regression — but review flagged it as a live bug worth its own change, and the sibling macOS PR (#24) has already moved that platform to a full hash.

On the DIB path it bites: DIBs are stored bottom-up, so 4096 bytes at 32bpp covers roughly the bottom 1000 pixels of the image — two screenshots that differ only above that row hash identically, and the second one is silently dropped as a duplicate. Review reproduced the collision.

I did not just mirror the macOS fix here, because it is not a like-for-like change on Windows: `pywin32` can hand back a `GlobalSize`-rounded buffer with arbitrary tail padding, and the prefix hash is incidentally robust to that padding in a way a full hash is not. Making Windows hash the whole buffer needs its own thought about trimming to `biSizeImage` first, which is more than this PR should carry.

## Tests

New `tests/unit/test_windows_clipboard.py`, 25 tests. This module had **0% coverage** — which is why four bugs survived in it — and is now at **72%**. Full suite: **112 passed** (87 pre-existing + 25 new).

The harness is the interesting part: the module cannot be imported off Windows (`import win32clipboard` fails, `from ctypes import windll` fails, `HAS_WIN32` goes False and the constructor raises `RuntimeError`), so a fixture installs fake pywin32 modules and a fake `ctypes.windll` into `sys.modules`, imports the module fresh per test, and restores everything on teardown. The fake clipboard is an in-memory dict that counts `OpenClipboard`/`CloseClipboard` calls, so tests can assert lock discipline directly.

Covered: the sequence-number gate (unchanged → never opens; changed → opens exactly once; each new change reopens; both failure fallbacks; `start()` seeding; recovery after a failed open; no re-open storm on an unreadable item), the PNG `try/finally` (register raises → still closed; open fails → not closed; `KeyboardInterrupt` propagates; per-instance not global), the file/image hash split (image echo via PNG and via DIB, file echo, text echo, and positive controls that new content *does* send), and `get_clipboard_files` always returning a list.

No test touches the real clipboard, binds a port, or starts a service.

## Not touched

`set_virtual_clipboard_files()` is left exactly as-is — it is being removed in a separate PR.

Pre-existing lint noise in this file (trailing whitespace, unused imports) was left alone to keep the diff readable; `ruff` findings for the file drop from 88 to 72, including all four `E722` bare-excepts. The new test file is clean under `ruff` and `black`. No new `mypy` errors (the file's existing errors are all missing pywin32 stubs and PIL typing).
