### PR TITLE
Skip macOS-only service tests on non-Darwin platforms

### DIFF
--- a/tests/unit/test_service_status.py
+++ b/tests/unit/test_service_status.py
@@ -7,6 +7,7 @@ Covers:
 - Self-healing: auto-install when paired but service missing
 """
 import subprocess
+import sys
 from pathlib import Path
 from unittest.mock import patch, MagicMock, PropertyMock
 
@@ -18,8 +19,13 @@ from yank.common.service_manager import ServiceInfo, ServiceStatus
 # ── macOS: Homebrew plist detection ──────────────────────────────────────
 
 
+@pytest.mark.skipif(sys.platform != "darwin", reason="macOS-only service manager")
 class TestMacOSHomebrewDetection:
-    """MacOSServiceManager.get_status() should detect Homebrew-managed plist."""
+    """MacOSServiceManager.get_status() should detect Homebrew-managed plist.
+
+    macOS-only: MacOSServiceManager.__init__ calls os.getuid(), which does not
+    exist on Windows.
+    """
 
     @pytest.fixture(autouse=True)
     def setup(self, tmp_path):


### PR DESCRIPTION
## What

Guards `tests/unit/test_service_status.py::TestMacOSHomebrewDetection` with `@pytest.mark.skipif(sys.platform != "darwin")`, and adds the `import sys` it needs.

## Why

The class had no platform guard, so its `autouse` fixture constructed `MacOSServiceManager` on every platform. `MacOSServiceManager.__init__` calls `os.getuid()` at [src/yank/platform/macos/service.py:29](https://github.com/nasiridrishi/yank/blob/master/src/yank/platform/macos/service.py#L29), which does not exist on Windows:

```
AttributeError: module 'os' has no attribute 'getuid'
src\yank\platform\macos\service.py:29: AttributeError
```

On a real `windows-latest` GitHub Actions runner this produced **82 passed, 5 errors** — one error per test in the class.

## Verification

- **macOS:** `pytest` → **87 passed**. The guarded class still runs on Darwin; this does not silently drop coverage where it matters.
- **Skip mechanism:** confirmed that a class-level `skipif` is evaluated *before* fixture setup, so the `autouse` fixture body — and the `MacOSServiceManager()` construction inside it — never executes off-Darwin. A structural probe mirroring this class, with a fixture that raises unconditionally, reported 5 skipped and 0 errors. Windows will therefore report **82 passed, 5 skipped, 0 errors**.

## Note for reviewers: `TestLinuxPackageUnitDetection` needs no guard

Checked deliberately, since a Linux-named class raises the same suspicion:

- `LinuxServiceManager.__init__` uses only `os.environ.get` and `Path.home()` — both portable.
- The fixture overrides `_unit_path` and `_system_unit_path` to `tmp_path`, so no real systemd path is touched.
- `get_status()` and `start()` reach outside only via `_systemctl`, which every test mocks.
- `SYSTEM_UNIT_PATH = Path("/usr/lib/systemd/user")` is inert on Windows — it just becomes a `WindowsPath` that is never used.

The Windows run corroborates this: exactly 5 errors, all from the macOS class.

## Follow-up (not in this PR)

`.github/workflows/ci.yml` does not exist on `master` — it lives only on `ci/add-pull-request-workflow`, whose `windows-latest` matrix entry carries the workaround this PR obsoletes:

```yaml
pytest_args: '--deselect tests/unit/test_service_status.py::TestMacOSHomebrewDetection'
```

That `pytest_args` value and its explanatory comment block should be deleted — but **only after this PR lands**. That branch is based on `master` and does not contain this fix, so dropping the deselect there today would turn its own Windows leg red with the same 5 errors. Suggested order: merge this, rebase the CI branch, then remove the workaround. The macOS entry's empty `pytest_args: ''` must stay, since the shared `run: pytest ${{ matrix.pytest_args }}` step references it for both entries.