### PR TITLE
Add __main__.py so python -m yank works

### DIFF
--- a/src/yank/__main__.py
+++ b/src/yank/__main__.py
@@ -1,0 +1,10 @@
+"""
+Yank - module entry point
+
+Allows running the CLI with `python -m yank` in addition to the
+`yank` console script.
+"""
+from yank.main import main
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What changed

Adds `src/yank/__main__.py`, a four-line shim delegating to `yank.main:main`.

## Why

The package had no `__main__.py`, so `python -m yank` failed outright:

```
No module named yank.__main__; 'yank' is a package and cannot be directly executed
```

Only the `yank` console script (`[project.scripts] yank = "yank.main:main"`) worked. This matters because `CLAUDE.md` documents `python -m yank status` and `python -m yank start --foreground` as the way to run from source — that documented workflow was broken.

The shim uses an absolute import (`from yank.main import main`) to match the import style used throughout `main.py`.

## Verification

Tested in a throwaway venv with `zeroconf` / `Pillow` / `cryptography`:

- `python -m yank --version` → `Yank 1.0.1`, exit 0
- `python -m yank status` → `[NOT INSTALLED] Service not installed` / `Not paired.`, exit 0
- `python -m yank start --help` → parses correctly; argparse usage line reads `python -m yank start [-h] [-p PEER] ...`
- Built a wheel and confirmed `yank/__main__.py` is in it — the existing `[tool.setuptools.packages.find]` config picks it up with no change needed, so installed copies get it too

## Notes for reviewers

Two things deliberately not run, to avoid touching a real background service:

- **`start --foreground`** starts the actual sync agent, so it was verified via `--help` rather than executed.
- **`status` against a real `$HOME`** — `main.py:541` has a self-healing branch where `status` *installs* the service when paired but not installed. The test machine wasn't paired (no `~/.clipboard-sync`, no yank LaunchAgent) so it would have been a no-op, but `HOME` was pointed at a scratch dir anyway so the test couldn't write to real config or LaunchAgents.

**Unrelated pre-existing issue spotted:** `__version__` in `src/yank/__init__.py` is `1.0.1` while `pyproject.toml` says `1.0.3` — which is why `--version` prints `1.0.1` above. Out of scope here, but the two will keep drifting until one sources from the other.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for launching the command-line interface with `python -m yank`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->