### PR TITLE
Handle SIGBREAK so Windows graceful stop runs cleanup

### DIFF
--- a/src/yank/main.py
+++ b/src/yank/main.py
@@ -711,6 +711,11 @@ def _run_foreground(args):
 
     signal.signal(signal.SIGINT, signal_handler)
     signal.signal(signal.SIGTERM, signal_handler)
+    # Windows-only: 'yank stop' sends CTRL_BREAK_EVENT to the agent's process
+    # group, which arrives as SIGBREAK. Without a handler the default
+    # disposition kills us before cleanup, stranding the singleton lock/PID.
+    if hasattr(signal, "SIGBREAK"):
+        signal.signal(signal.SIGBREAK, signal_handler)
 
     try:
         app.start()

--- a/tests/unit/test_signal_handlers.py
+++ b/tests/unit/test_signal_handlers.py
@@ -1,0 +1,94 @@
+"""
+Tests for signal handler registration in the foreground agent.
+
+Covers:
+- SIGINT/SIGTERM always registered
+- SIGBREAK registered only when the attribute exists (Windows-only), so
+  'yank stop' sending CTRL_BREAK_EVENT runs cleanup instead of hard-killing
+- The registered handler releases the singleton lock/PID pair
+"""
+import signal
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from yank import main as yank_main
+
+
+@pytest.fixture
+def foreground_args():
+    return SimpleNamespace(port=9876, peer=None, no_security=False, verbose=False)
+
+
+@pytest.fixture
+def patched_foreground():
+    """Stub out everything _run_foreground touches except signal registration."""
+    app = MagicMock()
+    pairing = MagicMock()
+    pairing.is_paired.return_value = True
+
+    with patch("yank.main.ensure_single_instance", return_value=True), \
+            patch("yank.main.get_pairing_manager", return_value=pairing), \
+            patch("yank.main.ClipboardSync", return_value=app), \
+            patch("yank.main.release_singleton") as mock_release, \
+            patch("yank.main.signal.signal") as mock_signal:
+        yield SimpleNamespace(app=app, release=mock_release, signal=mock_signal)
+
+
+def _registered(mock_signal):
+    """Map of signal number -> handler passed to signal.signal()."""
+    return {call.args[0]: call.args[1] for call in mock_signal.call_args_list}
+
+
+class TestForegroundSignalRegistration:
+
+    def test_sigint_and_sigterm_always_registered(self, patched_foreground, foreground_args):
+        yank_main._run_foreground(foreground_args)
+
+        handlers = _registered(patched_foreground.signal)
+        assert signal.SIGINT in handlers
+        assert signal.SIGTERM in handlers
+
+    def test_sigbreak_registered_when_attribute_exists(
+        self, patched_foreground, foreground_args, monkeypatch
+    ):
+        # SIGBREAK is Windows-only; simulate it so this runs on any host.
+        monkeypatch.setattr(signal, "SIGBREAK", 21, raising=False)
+
+        yank_main._run_foreground(foreground_args)
+
+        handlers = _registered(patched_foreground.signal)
+        assert signal.SIGBREAK in handlers
+        # CTRL_BREAK_EVENT must run the same graceful shutdown as Ctrl-C.
+        assert handlers[signal.SIGBREAK] is handlers[signal.SIGINT]
+
+    def test_sigbreak_not_registered_when_attribute_missing(
+        self, patched_foreground, foreground_args, monkeypatch
+    ):
+        monkeypatch.delattr(signal, "SIGBREAK", raising=False)
+
+        yank_main._run_foreground(foreground_args)
+
+        # Only SIGINT and SIGTERM on non-Windows hosts.
+        assert set(_registered(patched_foreground.signal)) == {
+            signal.SIGINT, signal.SIGTERM
+        }
+
+    def test_sigbreak_handler_stops_app_and_releases_singleton(
+        self, patched_foreground, foreground_args, monkeypatch
+    ):
+        monkeypatch.setattr(signal, "SIGBREAK", 21, raising=False)
+
+        yank_main._run_foreground(foreground_args)
+        handler = _registered(patched_foreground.signal)[signal.SIGBREAK]
+
+        patched_foreground.app.stop.reset_mock()
+        patched_foreground.release.reset_mock()
+
+        with pytest.raises(SystemExit) as exc:
+            handler(signal.SIGBREAK, None)
+
+        assert exc.value.code == 0
+        patched_foreground.app.stop.assert_called_once()
+        patched_foreground.release.assert_called_once()


### PR DESCRIPTION
## What

`_run_foreground()` in [src/yank/main.py](src/yank/main.py) now registers its existing `signal_handler` for `SIGBREAK` in addition to `SIGINT`/`SIGTERM`, guarded by `hasattr(signal, "SIGBREAK")` since the constant is Windows-only.

## Why

`WindowsServiceManager.stop()` attempts a graceful shutdown first, calling `GenerateConsoleCtrlEvent(CTRL_BREAK_EVENT, pid)` against the agent's process group (the child is launched with `CREATE_NEW_PROCESS_GROUP`) before falling back to `TerminateProcess`.

CPython / the MSVC CRT map `CTRL_BREAK_EVENT` onto **SIGBREAK**, not SIGINT. The agent only handled SIGINT and SIGTERM, so SIGBREAK hit its default disposition — terminate immediately, no handler. The result: the "graceful" path was behaviorally identical to the hard kill, `app.stop()` and `release_singleton()` never ran, and the singleton lock/PID pair was left stranded in `%TEMP%`.

Registering the same handler makes the graceful path actually graceful — it shuts the app down and releases the singleton before exiting 0.

## Tests

New [tests/unit/test_signal_handlers.py](tests/unit/test_signal_handlers.py) stubs `ensure_single_instance`, `get_pairing_manager`, `ClipboardSync`, `release_singleton`, and `signal.signal`, then inspects the recorded registrations:

- SIGINT and SIGTERM are always registered
- with `SIGBREAK` injected (`monkeypatch.setattr(..., raising=False)`), it is registered **and is the identical handler object** as SIGINT
- with `SIGBREAK` removed (`monkeypatch.delattr(..., raising=False)`), only SIGINT/SIGTERM are registered — deterministic on Windows runners too, not just implicitly on macOS/Linux
- invoking the registered SIGBREAK handler calls `app.stop()` and `release_singleton()` once each and raises `SystemExit(0)` — this is what actually covers the stranded-lock failure mode

Full suite passes (91 tests) on macOS.

## Reviewer note

This was developed and verified on a macOS host, so the end-to-end path — `GenerateConsoleCtrlEvent` → CRT → SIGBREAK delivery into a `CREATE_NEW_PROCESS_GROUP` child — was **not** exercised. The tests cover handler registration and handler behavior, not that Windows actually delivers the event. Worth a manual `yank start` / `yank stop` on Windows confirming the lock file in `%TEMP%` is gone afterward.