### PR TITLE
Give clipboard image spool files unique names

### DIFF
--- a/src/yank/platform/macos/clipboard.py
+++ b/src/yank/platform/macos/clipboard.py
@@ -243,11 +243,18 @@ class MacClipboardMonitor:
                     return
                 self._last_image_hash = data_hash
 
-            # Save to temp file
+            # Save to temp file. The name must be unique: large images are sent
+            # by announcement and read back from disk when the peer pulls them,
+            # so a second image reusing this path would serve the wrong bytes.
             timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-            filename = f"clipboard_image_{timestamp}.png"
-            filepath = self.temp_dir / filename
-            
+            fd, path_str = tempfile.mkstemp(
+                prefix=f"clipboard_image_{timestamp}_",
+                suffix=".png",
+                dir=self.temp_dir
+            )
+            os.close(fd)
+            filepath = Path(path_str)
+
             # Convert TIFF to PNG if needed
             if NSPasteboardTypeTIFF in self._pasteboard.types() and NSPasteboardTypePNG not in self._pasteboard.types():
                 # Use NSImage to convert
@@ -266,7 +273,7 @@ class MacClipboardMonitor:
                 with open(filepath, 'wb') as f:
                     f.write(data_bytes)
             
-            logger.info(f"Detected image in clipboard, saved to {filename}")
+            logger.info(f"Detected image in clipboard, saved to {filepath.name}")
             
             # Track to avoid loops
             with self._received_files_lock:

--- a/src/yank/platform/windows/clipboard.py
+++ b/src/yank/platform/windows/clipboard.py
@@ -332,14 +332,21 @@ class WindowsClipboardMonitor:
             if img is None:
                 return
             
-            # Save to temp file
+            # Save to temp file. The name must be unique: large images are sent
+            # by announcement and read back from disk when the peer pulls them,
+            # so a second image reusing this path would serve the wrong bytes.
             timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-            filename = f"clipboard_image_{timestamp}.png"
-            filepath = self.temp_dir / filename
-            
+            fd, path_str = tempfile.mkstemp(
+                prefix=f"clipboard_image_{timestamp}_",
+                suffix=".png",
+                dir=self.temp_dir
+            )
+            os.close(fd)
+            filepath = Path(path_str)
+
             img.save(filepath, 'PNG')
-            
-            logger.info(f"Detected image in clipboard, saved to {filename}")
+
+            logger.info(f"Detected image in clipboard, saved to {filepath.name}")
             
             # Track to avoid loops
             with self._received_files_lock:

--- a/tests/unit/test_macos_clipboard_image_spool.py
+++ b/tests/unit/test_macos_clipboard_image_spool.py
@@ -1,0 +1,266 @@
+"""
+Regression tests for the macOS clipboard image spool filename.
+
+These tests NEVER touch the real system pasteboard: ``NSPasteboard`` is patched
+out for a ``FakePasteboard`` before the monitor is constructed, so
+``NSPasteboard.generalPasteboard()`` never runs and nothing is written to the
+user's clipboard.
+
+``_handle_image()`` used to name its spool file from a second-resolution
+timestamp, so two images copied inside the same second landed on one path and
+the second silently overwrote the first. That matters for the lazy (>10 MB)
+transfer path in ``main.py``: FILE_ANNOUNCE sends only metadata and the file is
+read back from disk when the peer pulls it, so the peer could receive the wrong
+image bytes - or bytes whose size and checksum no longer matched what was
+announced.
+
+The clock is frozen in these tests so "within the same second" is guaranteed
+rather than left to chance.
+"""
+import sys
+import hashlib
+from datetime import datetime
+
+import pytest
+
+pytest.importorskip("AppKit", reason="pyobjc is required for the macOS clipboard monitor")
+
+pytestmark = pytest.mark.skipif(
+    sys.platform != "darwin", reason="macOS clipboard monitor is darwin-only"
+)
+
+from AppKit import (  # noqa: E402
+    NSPasteboardTypePNG,
+    NSPasteboardTypeTIFF,
+)
+
+from yank.platform.macos import clipboard as mac_clipboard  # noqa: E402
+from yank.platform.macos.clipboard import MacClipboardMonitor  # noqa: E402
+
+
+# --------------------------------------------------------------------------
+# Fakes
+# --------------------------------------------------------------------------
+
+
+class FakePasteboard:
+    """In-memory stand-in for NSPasteboard.
+
+    Only the reads ``_handle_image()`` performs are needed here; a "copy" is
+    modelled as replacing the contents and bumping ``changeCount``.
+    """
+
+    def __init__(self):
+        self._items = {}
+        self._change_count = 0
+
+    def changeCount(self):  # noqa: N802 - Cocoa naming
+        return self._change_count
+
+    def types(self):
+        return list(self._items.keys())
+
+    def dataForType_(self, type_):  # noqa: N802
+        return self._items.get(type_)
+
+    def propertyListForType_(self, type_):  # noqa: N802
+        return self._items.get(type_)
+
+    def stringForType_(self, type_):  # noqa: N802
+        return self._items.get(type_)
+
+    def pasteboardItems(self):  # noqa: N802
+        return []
+
+    def user_copies(self, **by_type):
+        """Simulate some other app putting content on the pasteboard."""
+        self._items.clear()
+        self._items.update(by_type)
+        self._change_count += 1
+
+
+class FakeNSPasteboardClass:
+    """Replaces the NSPasteboard *class* so generalPasteboard() is never called."""
+
+    def __init__(self, board):
+        self._board = board
+
+    def generalPasteboard(self):  # noqa: N802
+        return self._board
+
+
+FROZEN_NOW = datetime(2026, 7, 30, 14, 30, 22)
+FROZEN_STAMP = FROZEN_NOW.strftime("%Y%m%d_%H%M%S")
+
+
+class FrozenDatetime:
+    """Pins ``datetime.now()`` so every spool file lands in the same second."""
+
+    @staticmethod
+    def now():
+        return FROZEN_NOW
+
+
+# --------------------------------------------------------------------------
+# Fixtures / helpers
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture
+def pasteboard(monkeypatch):
+    board = FakePasteboard()
+    monkeypatch.setattr(mac_clipboard, "NSPasteboard", FakeNSPasteboardClass(board))
+    return board
+
+
+@pytest.fixture
+def frozen_clock(monkeypatch):
+    monkeypatch.setattr(mac_clipboard, "datetime", FrozenDatetime)
+
+
+@pytest.fixture
+def spool_dir(tmp_path):
+    return tmp_path / "spool"
+
+
+@pytest.fixture
+def monitor(pasteboard, frozen_clock, spool_dir):
+    """A monitor wired to the fake pasteboard, recording its callbacks."""
+    saved = []
+    mon = MacClipboardMonitor(
+        on_files_copied=lambda paths: saved.append(list(paths)),
+        temp_dir=spool_dir,
+        sync_files=False,
+        sync_images=True,
+        sync_text=False,
+    )
+    assert mon._pasteboard is pasteboard
+    mon.saved = saved
+    return mon
+
+
+def image_bytes(seed: bytes, size: int = 4096) -> bytes:
+    """Deterministic pseudo-image payload (never decoded, only hashed/written)."""
+    out = bytearray()
+    chunk = seed
+    while len(out) < size:
+        chunk = hashlib.sha256(chunk).digest()
+        out.extend(chunk)
+    return bytes(out[:size])
+
+
+IMAGE_A = image_bytes(b"a")
+IMAGE_B = image_bytes(b"b", size=8192)  # deliberately a different size
+
+
+def copy_png(pasteboard, monitor, payload):
+    pasteboard.user_copies(**{NSPasteboardTypePNG: payload})
+    monitor._check_clipboard()
+
+
+# --------------------------------------------------------------------------
+# The collision
+# --------------------------------------------------------------------------
+
+
+class TestSpoolFilesDoNotCollide:
+    def test_two_images_in_one_second_get_distinct_paths(self, monitor, pasteboard):
+        copy_png(pasteboard, monitor, IMAGE_A)
+        copy_png(pasteboard, monitor, IMAGE_B)
+
+        assert len(monitor.saved) == 2, "second image was not detected"
+        [first] = monitor.saved[0]
+        [second] = monitor.saved[1]
+
+        assert first != second, "both images were spooled to the same path"
+
+    def test_the_first_image_is_not_overwritten(self, monitor, pasteboard):
+        copy_png(pasteboard, monitor, IMAGE_A)
+        [first] = monitor.saved[0]
+        assert first.read_bytes() == IMAGE_A
+
+        copy_png(pasteboard, monitor, IMAGE_B)
+        [second] = monitor.saved[1]
+
+        # The whole point: announcing the first image and pulling it later must
+        # still yield the first image.
+        assert first.read_bytes() == IMAGE_A, "second copy clobbered the first image"
+        assert second.read_bytes() == IMAGE_B
+
+    def test_announced_size_and_checksum_stay_valid(self, monitor, pasteboard):
+        """What the lazy transfer path actually depends on.
+
+        FILE_ANNOUNCE captures size/checksum up front; the bytes are read from
+        disk later. Both must still describe the file when the peer pulls it.
+        """
+        copy_png(pasteboard, monitor, IMAGE_A)
+        [announced] = monitor.saved[0]
+
+        announced_size = announced.stat().st_size
+        announced_checksum = hashlib.sha256(announced.read_bytes()).hexdigest()
+
+        copy_png(pasteboard, monitor, IMAGE_B)
+
+        assert announced.stat().st_size == announced_size
+        assert hashlib.sha256(announced.read_bytes()).hexdigest() == announced_checksum
+        assert announced_size == len(IMAGE_A)
+
+    def test_a_burst_of_images_all_survive(self, monitor, pasteboard, spool_dir):
+        payloads = [image_bytes(f"burst-{i}".encode()) for i in range(6)]
+
+        for payload in payloads:
+            copy_png(pasteboard, monitor, payload)
+
+        assert len(monitor.saved) == len(payloads)
+
+        paths = [entry[0] for entry in monitor.saved]
+        assert len({str(p) for p in paths}) == len(payloads), "spool paths collided"
+
+        for path, payload in zip(paths, payloads):
+            assert path.read_bytes() == payload
+
+        # Nothing was lost or left behind in the spool directory either.
+        assert sorted(p.name for p in spool_dir.iterdir()) == sorted(p.name for p in paths)
+
+    def test_tiff_fallback_writes_also_get_distinct_paths(self, monitor, pasteboard):
+        """The TIFF branch writes through a different code path to the same name."""
+        pasteboard.user_copies(**{NSPasteboardTypeTIFF: IMAGE_A})
+        monitor._check_clipboard()
+        pasteboard.user_copies(**{NSPasteboardTypeTIFF: IMAGE_B})
+        monitor._check_clipboard()
+
+        assert len(monitor.saved) == 2
+        [first] = monitor.saved[0]
+        [second] = monitor.saved[1]
+        assert first != second
+        assert first.exists() and second.exists()
+
+
+# --------------------------------------------------------------------------
+# ...without breaking how the file is named or where it goes
+# --------------------------------------------------------------------------
+
+
+class TestSpoolNaming:
+    def test_name_keeps_its_prefix_timestamp_and_extension(
+        self, monitor, pasteboard, spool_dir
+    ):
+        copy_png(pasteboard, monitor, IMAGE_A)
+        [path] = monitor.saved[0]
+
+        assert path.parent == spool_dir
+        assert path.name.startswith(f"clipboard_image_{FROZEN_STAMP}_")
+        assert path.suffix == ".png"
+
+    def test_unique_part_is_what_differs(self, monitor, pasteboard):
+        copy_png(pasteboard, monitor, IMAGE_A)
+        copy_png(pasteboard, monitor, IMAGE_B)
+
+        [first] = monitor.saved[0]
+        [second] = monitor.saved[1]
+
+        prefix = f"clipboard_image_{FROZEN_STAMP}_"
+        assert first.name.startswith(prefix)
+        assert second.name.startswith(prefix)
+        # Same second, same prefix - only the unique suffix separates them.
+        assert first.stem != second.stem


### PR DESCRIPTION
## What

`MacClipboardMonitor._handle_image()` named its spool file from a second-resolution timestamp:

```python
timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
filename = f"clipboard_image_{timestamp}.png"
filepath = self.temp_dir / filename
```

Two images copied within the same second therefore resolved to the same path, and the second overwrote the first. The path is now allocated with `tempfile.mkstemp`.

`WindowsClipboardMonitor._handle_image()` had the identical pattern and gets the identical fix.

## Why it matters

This corrupts the lazy (>10 MB) transfer path in `main.py`. `FILE_ANNOUNCE` sends only metadata, and the bytes are read back from disk when the peer pulls them — so between the announcement and the pull, a second same-second image can replace the file. The peer then receives the wrong image, or bytes whose size and checksum no longer match what was announced.

## How

```python
timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
fd, path_str = tempfile.mkstemp(
    prefix=f"clipboard_image_{timestamp}_", suffix=".png", dir=self.temp_dir
)
os.close(fd)
filepath = Path(path_str)
```

`mkstemp` over a uuid4 suffix because it reserves the name atomically rather than relying on collision probability, and it needs no new import — both modules already import `os` and `tempfile`. The human-readable timestamp is kept as the prefix, so names still look like `clipboard_image_20260730_143022_x7f2ab.png`. The macOS log line referenced the removed `filename` variable, so both now log `filepath.name`.

Linux has no image spool path, and nothing anywhere parses or globs this filename, so the format change is safe.

## Tests

New `tests/unit/test_macos_clipboard_image_spool.py`, 7 tests. `NSPasteboard` is patched to an in-memory `FakePasteboard` before the monitor is constructed, so `generalPasteboard()` never runs and **the real system pasteboard is never touched**. `datetime.now()` is frozen — otherwise "within the same second" is left to chance and the tests could pass for the wrong reason.

Covers: distinct paths for two same-second copies; the first image's bytes surviving the second; size and checksum still matching after a later copy (the actual `FILE_ANNOUNCE` failure mode); a 6-image burst all surviving; the TIFF fallback branch, which writes through different code to the same name; and naming tests pinning the prefix, timestamp, extension, and parent directory.

Verified the tests fail against the old code, not just pass against the new — with the macOS fix stashed, all 7 fail, and the output shows both images landing on `clipboard_image_20260730_143022.png`. Restored, all 7 pass. Full suite: 94 passed.

## Reviewer notes

- **The Windows change is untested by me.** `WindowsClipboardMonitor.__init__` calls `win32clipboard` at construction, so it can't be instantiated on macOS; any test would be permanently skipped and unverifiable here. The change is the same three lines as macOS and compiles clean, but it's worth a run on a Windows machine.
- **Test filename.** Named `test_macos_clipboard_image_spool.py` rather than added to `test_macos_clipboard.py`, which doesn't exist on `master` — it's added by the unmerged issue #16 PR (`fix/macos-clipboard-image-echo-loop`). A separate file avoids a merge conflict. When that PR lands, one of its assertions goes harmlessly stale: `test_images_sharing_a_4kb_prefix_are_treated_as_different` carries a comment saying both spool files can share a name, which is no longer true after this fix. The test itself still passes.
- This bug was spotted while fixing the macOS clipboard echo loop (issue #16) and deliberately left out of that PR to keep it scoped.